### PR TITLE
Add resilient streaming recorder

### DIFF
--- a/ai-scribe-copilot/android/app/src/main/AndroidManifest.xml
+++ b/ai-scribe-copilot/android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />

--- a/ai-scribe-copilot/android/app/src/main/kotlin/com/aiscribe/copilot/ai_scribe_copilot/MainActivity.kt
+++ b/ai-scribe-copilot/android/app/src/main/kotlin/com/aiscribe/copilot/ai_scribe_copilot/MainActivity.kt
@@ -1,5 +1,134 @@
 package com.aiscribe.copilot.ai_scribe_copilot
 
+import android.content.Context
+import android.media.AudioAttributes
+import android.media.AudioFocusRequest
+import android.media.AudioManager
+import android.os.Build
+import android.os.Bundle
+import android.telephony.PhoneStateListener
+import android.telephony.TelephonyManager
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.EventChannel
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+    private val methodChannelName = "ai_scribe_copilot/mic"
+    private val eventChannelName = "ai_scribe_copilot/interruption"
+    private var eventSink: EventChannel.EventSink? = null
+    private lateinit var audioManager: AudioManager
+    private var audioFocusRequest: AudioFocusRequest? = null
+    private var phoneStateListener: PhoneStateListener? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
+        registerPhoneStateListener()
+    }
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, methodChannelName)
+            .setMethodCallHandler(::handleMethodCall)
+        EventChannel(flutterEngine.dartExecutor.binaryMessenger, eventChannelName)
+            .setStreamHandler(object : EventChannel.StreamHandler {
+                override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
+                    eventSink = events
+                }
+
+                override fun onCancel(arguments: Any?) {
+                    eventSink = null
+                }
+            })
+    }
+
+    private fun handleMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        when (call.method) {
+            "setGain" -> {
+                val gain = (call.argument<Number>("gain")?.toFloat()) ?: 1.0f
+                setInputGain(gain)
+                result.success(null)
+            }
+            "requestFocus" -> {
+                requestAudioFocus()
+                result.success(null)
+            }
+            "abandonFocus" -> {
+                abandonAudioFocus()
+                result.success(null)
+            }
+            else -> result.notImplemented()
+        }
+    }
+
+    private fun setInputGain(gain: Float) {
+        // While Android does not expose direct microphone gain APIs, we map this
+        // request to the VOICE_COMMUNICATION stream to bias AGC.
+        val scaled = (audioManager.getStreamMaxVolume(AudioManager.STREAM_VOICE_CALL) * gain).toInt()
+        val clamped = scaled.coerceIn(1, audioManager.getStreamMaxVolume(AudioManager.STREAM_VOICE_CALL))
+        audioManager.setStreamVolume(AudioManager.STREAM_VOICE_CALL, clamped, 0)
+    }
+
+    private fun requestAudioFocus() {
+        val listener = AudioManager.OnAudioFocusChangeListener { focusChange ->
+            when (focusChange) {
+                AudioManager.AUDIOFOCUS_GAIN -> emitEvent("audioFocusGained")
+                AudioManager.AUDIOFOCUS_LOSS, AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> emitEvent("audioFocusLost")
+            }
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val request = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE)
+                .setAudioAttributes(
+                    AudioAttributes.Builder()
+                        .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                        .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
+                        .build()
+                )
+                .setOnAudioFocusChangeListener(listener)
+                .build()
+            audioFocusRequest = request
+            audioManager.requestAudioFocus(request)
+        } else {
+            audioManager.requestAudioFocus(
+                listener,
+                AudioManager.STREAM_VOICE_CALL,
+                AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE
+            )
+        }
+    }
+
+    private fun abandonAudioFocus() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            audioFocusRequest?.let { audioManager.abandonAudioFocusRequest(it) }
+        } else {
+            audioManager.abandonAudioFocus(null)
+        }
+    }
+
+    private fun registerPhoneStateListener() {
+        val telephonyManager = getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
+        phoneStateListener = object : PhoneStateListener() {
+            override fun onCallStateChanged(state: Int, phoneNumber: String?) {
+                when (state) {
+                    TelephonyManager.CALL_STATE_OFFHOOK, TelephonyManager.CALL_STATE_RINGING -> emitEvent("phoneCallStarted")
+                    TelephonyManager.CALL_STATE_IDLE -> emitEvent("phoneCallEnded")
+                }
+            }
+        }
+        telephonyManager.listen(phoneStateListener, PhoneStateListener.LISTEN_CALL_STATE)
+    }
+
+    private fun emitEvent(type: String) {
+        runOnUiThread {
+            eventSink?.success(mapOf("type" to type))
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        val telephonyManager = getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
+        phoneStateListener?.let { telephonyManager.listen(it, PhoneStateListener.LISTEN_NONE) }
+    }
+}

--- a/ai-scribe-copilot/ios/Runner/AppDelegate.swift
+++ b/ai-scribe-copilot/ios/Runner/AppDelegate.swift
@@ -1,13 +1,139 @@
+import AVFoundation
+import CallKit
 import Flutter
 import UIKit
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterStreamHandler, CXCallObserverDelegate {
+  private let methodChannelName = "ai_scribe_copilot/mic"
+  private let eventChannelName = "ai_scribe_copilot/interruption"
+  private var eventSink: FlutterEventSink?
+  private let audioSession = AVAudioSession.sharedInstance()
+  private let callObserver = CXCallObserver()
+
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    guard let controller = window?.rootViewController as? FlutterViewController else {
+      return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    }
+
+    let methodChannel = FlutterMethodChannel(name: methodChannelName, binaryMessenger: controller.binaryMessenger)
+    methodChannel.setMethodCallHandler(handle)
+
+    let eventChannel = FlutterEventChannel(name: eventChannelName, binaryMessenger: controller.binaryMessenger)
+    eventChannel.setStreamHandler(self)
+
+    configureAudioSession()
+    callObserver.setDelegate(self, queue: nil)
+
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(handleInterruption(_:)),
+      name: AVAudioSession.interruptionNotification,
+      object: nil
+    )
+
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  private func handle(_ call: FlutterMethodCall, result: FlutterResult) {
+    switch call.method {
+    case "setGain":
+      if let gain = (call.arguments as? [String: Any])?["gain"] as? Double {
+        setInputGain(gain: gain)
+      }
+      result(nil)
+    case "requestFocus":
+      requestAudioFocus()
+      result(nil)
+    case "abandonFocus":
+      abandonAudioFocus()
+      result(nil)
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  private func configureAudioSession() {
+    do {
+      try audioSession.setCategory(.playAndRecord, mode: .voiceChat, options: [.allowBluetooth, .allowBluetoothA2DP, .duckOthers])
+      try audioSession.setPreferredSampleRate(16_000)
+      try audioSession.setPreferredIOBufferDuration(0.02)
+    } catch {
+      NSLog("Failed to configure audio session: \(error)")
+    }
+  }
+
+  private func setInputGain(gain: Double) {
+    guard audioSession.isInputGainSettable else { return }
+    do {
+      try audioSession.setInputGain(Float(min(max(gain, 0.0), 1.0)))
+    } catch {
+      NSLog("Failed to set input gain: \(error)")
+    }
+  }
+
+  private func requestAudioFocus() {
+    do {
+      try audioSession.setActive(true, options: [])
+    } catch {
+      NSLog("Failed to activate audio session: \(error)")
+    }
+  }
+
+  private func abandonAudioFocus() {
+    do {
+      try audioSession.setActive(false, options: [.notifyOthersOnDeactivation])
+    } catch {
+      NSLog("Failed to deactivate audio session: \(error)")
+    }
+  }
+
+  @objc private func handleInterruption(_ notification: Notification) {
+    guard let info = notification.userInfo,
+          let typeValue = info[AVAudioSessionInterruptionTypeKey] as? UInt,
+          let type = AVAudioSession.InterruptionType(rawValue: typeValue) else {
+      return
+    }
+    switch type {
+    case .began:
+      emitEvent(type: "audioFocusLost")
+    case .ended:
+      emitEvent(type: "audioFocusGained")
+    @unknown default:
+      break
+    }
+  }
+
+  private func emitEvent(type: String) {
+    DispatchQueue.main.async {
+      self.eventSink?(["type": type])
+    }
+  }
+
+  // MARK: - FlutterStreamHandler
+  func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
+    eventSink = events
+    return nil
+  }
+
+  func onCancel(withArguments arguments: Any?) -> FlutterError? {
+    eventSink = nil
+    return nil
+  }
+
+  // MARK: - CXCallObserverDelegate
+  deinit {
+    NotificationCenter.default.removeObserver(self)
+  }
+  func callObserver(_ callObserver: CXCallObserver, callChanged call: CXCall) {
+    if call.hasEnded {
+      emitEvent(type: "phoneCallEnded")
+    } else if call.isOutgoing || call.hasConnected {
+      emitEvent(type: "phoneCallStarted")
+    }
   }
 }

--- a/ai-scribe-copilot/lib/app.dart
+++ b/ai-scribe-copilot/lib/app.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'features/home/home_screen.dart';
+import 'shared/providers.dart';
+import 'utils/theme.dart';
+
+class AiScribeApp extends ConsumerWidget {
+  const AiScribeApp({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = ref.watch(themeProvider);
+    return MaterialApp(
+      title: 'AI Scribe Copilot',
+      theme: theme.light,
+      darkTheme: theme.dark,
+      themeMode: ThemeMode.system,
+      home: const HomeScreen(),
+    );
+  }
+}

--- a/ai-scribe-copilot/lib/bootstrap.dart
+++ b/ai-scribe-copilot/lib/bootstrap.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'app.dart';
+import 'shared/providers.dart';
+
+Future<void> bootstrap() async {
+  final container = ProviderContainer(overrides: await buildOverrides());
+  runApp(UncontrolledProviderScope(
+    container: container,
+    child: const AiScribeApp(),
+  ));
+}

--- a/ai-scribe-copilot/lib/core/models/patient.dart
+++ b/ai-scribe-copilot/lib/core/models/patient.dart
@@ -1,0 +1,24 @@
+class Patient {
+  const Patient({
+    required this.id,
+    required this.name,
+    required this.dateOfBirth,
+    required this.mrn,
+  });
+
+  final String id;
+  final String name;
+  final DateTime? dateOfBirth;
+  final String? mrn;
+
+  factory Patient.fromJson(Map<String, dynamic> json) {
+    return Patient(
+      id: json['id'].toString(),
+      name: json['name'] as String,
+      dateOfBirth: json['dateOfBirth'] != null
+          ? DateTime.tryParse(json['dateOfBirth'] as String)
+          : null,
+      mrn: json['mrn'] as String?,
+    );
+  }
+}

--- a/ai-scribe-copilot/lib/core/models/recording_chunk.dart
+++ b/ai-scribe-copilot/lib/core/models/recording_chunk.dart
@@ -1,0 +1,65 @@
+import 'dart:convert';
+
+class RecordingChunk {
+  RecordingChunk({
+    required this.id,
+    required this.sessionId,
+    required this.sequence,
+    required this.filePath,
+    required this.createdAt,
+    this.uploadedAt,
+    this.retryCount = 0,
+  });
+
+  final String id;
+  final String sessionId;
+  final int sequence;
+  final String filePath;
+  final DateTime createdAt;
+  final DateTime? uploadedAt;
+  final int retryCount;
+
+  RecordingChunk copyWith({
+    DateTime? uploadedAt,
+    int? retryCount,
+  }) {
+    return RecordingChunk(
+      id: id,
+      sessionId: sessionId,
+      sequence: sequence,
+      filePath: filePath,
+      createdAt: createdAt,
+      uploadedAt: uploadedAt ?? this.uploadedAt,
+      retryCount: retryCount ?? this.retryCount,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'sessionId': sessionId,
+      'sequence': sequence,
+      'filePath': filePath,
+      'createdAt': createdAt.toIso8601String(),
+      'uploadedAt': uploadedAt?.toIso8601String(),
+      'retryCount': retryCount,
+    };
+  }
+
+  factory RecordingChunk.fromJson(Map<String, dynamic> json) {
+    return RecordingChunk(
+      id: json['id'] as String,
+      sessionId: json['sessionId'] as String,
+      sequence: json['sequence'] as int,
+      filePath: json['filePath'] as String,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      uploadedAt: json['uploadedAt'] != null
+          ? DateTime.parse(json['uploadedAt'] as String)
+          : null,
+      retryCount: json['retryCount'] as int,
+    );
+  }
+
+  @override
+  String toString() => jsonEncode(toJson());
+}

--- a/ai-scribe-copilot/lib/core/models/upload_session.dart
+++ b/ai-scribe-copilot/lib/core/models/upload_session.dart
@@ -1,0 +1,13 @@
+class UploadSession {
+  UploadSession({
+    required this.sessionId,
+    required this.patientId,
+    required this.userId,
+    required this.startedAt,
+  });
+
+  final String sessionId;
+  final String patientId;
+  final String userId;
+  final DateTime startedAt;
+}

--- a/ai-scribe-copilot/lib/core/network/api_client.dart
+++ b/ai-scribe-copilot/lib/core/network/api_client.dart
@@ -1,0 +1,68 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+
+import '../../utils/logger.dart';
+import 'api_endpoints.dart';
+
+class ApiClient {
+  ApiClient({required this.logger}) {
+    _dio = Dio(
+      BaseOptions(
+        baseUrl: ApiEndpoints.baseUrl,
+        connectTimeout: const Duration(seconds: 10),
+        receiveTimeout: const Duration(seconds: 30),
+      ),
+    );
+  }
+
+  final Logger logger;
+  late final Dio _dio;
+
+  Future<Map<String, dynamic>> post(
+    String path, {
+    Map<String, dynamic>? data,
+    Options? options,
+  }) async {
+    logger.d('POST $path');
+    final response = await _dio.post(path, data: data, options: options);
+    return _decode(response);
+  }
+
+  Future<Map<String, dynamic>> get(
+    String path, {
+    Map<String, dynamic>? queryParameters,
+    Options? options,
+  }) async {
+    logger.d('GET $path');
+    final response = await _dio.get(
+      path,
+      queryParameters: queryParameters,
+      options: options,
+    );
+    return _decode(response);
+  }
+
+  Future<Response<dynamic>> putRaw(
+    String url, {
+    required List<int> data,
+    Map<String, dynamic>? headers,
+  }) async {
+    logger.d('PUT $url (raw upload)');
+    return _dio.put(
+      url,
+      data: Stream.fromIterable([data]),
+      options: Options(headers: headers),
+    );
+  }
+
+  Map<String, dynamic> _decode(Response response) {
+    if (response.data is Map<String, dynamic>) {
+      return response.data as Map<String, dynamic>;
+    }
+    if (response.data is String) {
+      return jsonDecode(response.data as String) as Map<String, dynamic>;
+    }
+    throw StateError('Unexpected response type: ${response.data.runtimeType}');
+  }
+}

--- a/ai-scribe-copilot/lib/core/network/api_endpoints.dart
+++ b/ai-scribe-copilot/lib/core/network/api_endpoints.dart
@@ -1,0 +1,11 @@
+class ApiEndpoints {
+  static const String baseUrl = 'https://api.medical-scribe.example';
+
+  static const String startSession = '/v1/upload-session';
+  static const String presignedUrl = '/v1/get-presigned-url';
+  static const String notifyChunkUploaded = '/v1/notify-chunk-uploaded';
+  static const String patients = '/v1/patients';
+  static const String addPatient = '/v1/add-patient-ext';
+  static String sessionsByPatient(String patientId) =>
+      '/v1/fetch-session-by-patient/$patientId';
+}

--- a/ai-scribe-copilot/lib/core/services/audio_recorder_service.dart
+++ b/ai-scribe-copilot/lib/core/services/audio_recorder_service.dart
@@ -1,0 +1,127 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_sound/flutter_sound.dart';
+import 'package:path_provider/path_provider.dart';
+
+import '../../utils/logger.dart';
+import '../models/recording_chunk.dart';
+import 'chunk_persistence_service.dart';
+import 'interruption_handler.dart';
+
+class AudioRecorderService {
+  AudioRecorderService({
+    required this.logger,
+    required this.chunkPersistenceService,
+    required this.interruptionHandler,
+    this.chunkSizeBytes = 16000 * 2 * 5,
+  })  : _recorder = FlutterSoundRecorder(),
+        _chunkStreamController = StreamController<RecordingChunk>.broadcast();
+
+  final Logger logger;
+  final ChunkPersistenceService chunkPersistenceService;
+  final InterruptionHandler interruptionHandler;
+  final int chunkSizeBytes;
+  final FlutterSoundRecorder _recorder;
+  final StreamController<RecordingChunk> _chunkStreamController;
+  StreamSubscription? _recordingSubscription;
+  String? _activeSessionId;
+  int _chunkSequence = 0;
+  final List<int> _buffer = <int>[];
+  bool _initialized = false;
+
+  Stream<RecordingChunk> get chunkStream => _chunkStreamController.stream;
+
+  Future<void> initialize() async {
+    if (_initialized) return;
+    await _recorder.openRecorder();
+    _initialized = true;
+  }
+
+  Future<void> dispose() async {
+    await _recordingSubscription?.cancel();
+    await _recorder.closeRecorder();
+    await _chunkStreamController.close();
+  }
+
+  bool get isRecording => _recorder.isRecording;
+
+  Future<void> startRecording(String sessionId, {bool resetSequence = false}) async {
+    if (!_initialized) {
+      await initialize();
+    }
+    if (resetSequence) {
+      _chunkSequence = 0;
+    }
+    _buffer.clear();
+    _activeSessionId = sessionId;
+    await interruptionHandler.requestAudioFocus();
+    await interruptionHandler.setGain(1.2);
+    final directory = await getTemporaryDirectory();
+    _recordingSubscription?.cancel();
+    _recordingSubscription = _recorder.onProgress?.listen(_onProgress);
+    await _recorder.startRecorder(
+      toStream: (Food data) async {
+        if (data.buffer == null) return;
+        _buffer.addAll(data.buffer!);
+        if (_buffer.length >= chunkSizeBytes) {
+          await _flushBuffer(directory);
+        }
+      },
+      codec: Codec.pcm16,
+      numChannels: 1,
+      sampleRate: 16000,
+    );
+    logger.i('Recording started for session $sessionId');
+  }
+
+  void _onProgress(RecordingDisposition disposition) {
+    logger.d('Recording level: ${disposition.decibels}');
+  }
+
+  Future<void> _flushBuffer(Directory directory) async {
+    final sessionId = _activeSessionId;
+    if (sessionId == null || _buffer.isEmpty) {
+      return;
+    }
+    final file = File('${directory.path}/chunk_${DateTime.now().microsecondsSinceEpoch}.pcm');
+    await file.writeAsBytes(_buffer.toList(), flush: true);
+    _buffer.clear();
+    final chunk = await chunkPersistenceService.addChunk(
+      sessionId: sessionId,
+      sequence: _chunkSequence++,
+      filePath: file.path,
+    );
+    _chunkStreamController.add(chunk);
+  }
+
+  Future<void> stopRecording({bool flushRemaining = true, bool clearSession = true}) async {
+    if (!_recorder.isRecording) return;
+    await _recorder.stopRecorder();
+    await interruptionHandler.abandonAudioFocus();
+    if (flushRemaining) {
+      final directory = await getTemporaryDirectory();
+      await _flushBuffer(directory);
+    } else {
+      _buffer.clear();
+    }
+    logger.i('Recording stopped for session $_activeSessionId');
+    if (clearSession) {
+      _activeSessionId = null;
+    }
+  }
+
+  Future<void> handleInterruption(InterruptionEvent event) async {
+    if (event.type == InterruptionEventType.phoneCallStarted ||
+        event.type == InterruptionEventType.audioFocusLost) {
+      if (_recorder.isRecording && _activeSessionId != null) {
+        await stopRecording(flushRemaining: false, clearSession: false);
+      }
+    } else if (event.type == InterruptionEventType.phoneCallEnded ||
+        event.type == InterruptionEventType.audioFocusGained) {
+      if (_activeSessionId != null && !_recorder.isRecording) {
+        await startRecording(_activeSessionId!);
+      }
+    }
+  }
+}

--- a/ai-scribe-copilot/lib/core/services/background_task_manager.dart
+++ b/ai-scribe-copilot/lib/core/services/background_task_manager.dart
@@ -1,0 +1,55 @@
+import 'dart:async';
+
+import 'package:flutter_background_service/flutter_background_service.dart';
+import 'package:flutter_background_service_android/flutter_background_service_android.dart';
+
+import '../../utils/logger.dart';
+
+class BackgroundTaskManager {
+  BackgroundTaskManager({required this.logger});
+
+  final Logger logger;
+  final FlutterBackgroundService _service = FlutterBackgroundService();
+
+  Future<void> initialize() async {
+    await _service.configure(
+      androidConfiguration: AndroidConfiguration(
+        onStart: _onStart,
+        autoStart: false,
+        isForegroundMode: true,
+      ),
+      iosConfiguration: IosConfiguration(
+        onForeground: _onStart,
+        onBackground: _onIosBackground,
+      ),
+    );
+  }
+
+  Future<void> ensureServiceRunning() async {
+    final isRunning = await _service.isRunning();
+    if (!isRunning) {
+      logger.d('Starting background service');
+      await _service.startService();
+    }
+  }
+
+  Future<void> stopService() async {
+    if (await _service.isRunning()) {
+      await _service.stopService();
+    }
+  }
+
+  static Future<void> _onStart(ServiceInstance service) async {
+    if (service is AndroidServiceInstance) {
+      service.setAsForegroundService();
+      service.setForegroundNotificationInfo(
+        title: 'AI Scribe Copilot',
+        content: 'Capturing clinical audio securely',
+      );
+    }
+  }
+
+  static Future<bool> _onIosBackground(ServiceInstance service) async {
+    return true;
+  }
+}

--- a/ai-scribe-copilot/lib/core/services/chunk_persistence_service.dart
+++ b/ai-scribe-copilot/lib/core/services/chunk_persistence_service.dart
@@ -1,0 +1,142 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:path_provider/path_provider.dart';
+import 'package:sqflite/sqflite.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../utils/logger.dart';
+import '../models/recording_chunk.dart';
+
+class ChunkPersistenceService {
+  ChunkPersistenceService({required this.logger});
+
+  final Logger logger;
+  Database? _database;
+  final _uuid = const Uuid();
+
+  Future<void> ensureInitialized() async {
+    if (_database != null) {
+      return;
+    }
+    final directory = await getApplicationDocumentsDirectory();
+    final dbPath = path.join(directory.path, 'recording_chunks.db');
+    _database = await openDatabase(
+      dbPath,
+      version: 1,
+      onCreate: (db, version) async {
+        await db.execute('''
+          CREATE TABLE chunks (
+            id TEXT PRIMARY KEY,
+            sessionId TEXT NOT NULL,
+            sequence INTEGER NOT NULL,
+            filePath TEXT NOT NULL,
+            createdAt TEXT NOT NULL,
+            uploadedAt TEXT,
+            retryCount INTEGER NOT NULL
+          );
+        ''');
+      },
+    );
+  }
+
+  Future<RecordingChunk> addChunk({
+    required String sessionId,
+    required int sequence,
+    required String filePath,
+  }) async {
+    final chunk = RecordingChunk(
+      id: _uuid.v4(),
+      sessionId: sessionId,
+      sequence: sequence,
+      filePath: filePath,
+      createdAt: DateTime.now().toUtc(),
+      retryCount: 0,
+    );
+    await _database!.insert('chunks', chunk.toJson());
+    logger.d('Persisted chunk ${chunk.id} for session $sessionId');
+    return chunk;
+  }
+
+  Future<void> markUploaded(String chunkId) async {
+    await _database!.update(
+      'chunks',
+      {
+        'uploadedAt': DateTime.now().toUtc().toIso8601String(),
+        'retryCount': 0,
+      },
+      where: 'id = ?',
+      whereArgs: [chunkId],
+    );
+  }
+
+  Future<void> incrementRetry(String chunkId) async {
+    await _database!.rawUpdate(
+      'UPDATE chunks SET retryCount = retryCount + 1 WHERE id = ?',
+      [chunkId],
+    );
+  }
+
+  Future<void> deleteChunk(String chunkId) async {
+    final chunk = await getChunkById(chunkId);
+    if (chunk != null) {
+      final file = File(chunk.filePath);
+      if (await file.exists()) {
+        await file.delete();
+      }
+    }
+    await _database!.delete(
+      'chunks',
+      where: 'id = ?',
+      whereArgs: [chunkId],
+    );
+  }
+
+  Future<RecordingChunk?> getChunkById(String chunkId) async {
+    final rows = await _database!.query(
+      'chunks',
+      where: 'id = ?',
+      whereArgs: [chunkId],
+    );
+    if (rows.isEmpty) {
+      return null;
+    }
+    return RecordingChunk.fromJson(rows.first);
+  }
+
+  Future<List<RecordingChunk>> pendingChunks({String? sessionId}) async {
+    final where = <String>[];
+    final args = <Object?>[];
+    where.add('uploadedAt IS NULL');
+    if (sessionId != null) {
+      where.add('sessionId = ?');
+      args.add(sessionId);
+    }
+    final rows = await _database!.query(
+      'chunks',
+      where: where.isEmpty ? null : where.join(' AND '),
+      whereArgs: args.isEmpty ? null : args,
+      orderBy: 'createdAt ASC',
+    );
+    return rows.map(RecordingChunk.fromJson).toList();
+  }
+
+  Future<void> clearSession(String sessionId) async {
+    final rows = await _database!.query(
+      'chunks',
+      where: 'sessionId = ?',
+      whereArgs: [sessionId],
+    );
+    for (final row in rows) {
+      final file = File(row['filePath'] as String);
+      if (await file.exists()) {
+        await file.delete();
+      }
+    }
+    await _database!.delete(
+      'chunks',
+      where: 'sessionId = ?',
+      whereArgs: [sessionId],
+    );
+  }
+}

--- a/ai-scribe-copilot/lib/core/services/chunk_uploader.dart
+++ b/ai-scribe-copilot/lib/core/services/chunk_uploader.dart
@@ -1,0 +1,133 @@
+import 'dart:async';
+import 'dart:io';
+
+import '../../utils/logger.dart';
+import '../models/recording_chunk.dart';
+import '../models/upload_session.dart';
+import 'background_task_manager.dart';
+import 'chunk_persistence_service.dart';
+import 'connectivity_monitor.dart';
+import 'upload_session_service.dart';
+
+class ChunkUploader {
+  ChunkUploader({
+    required this.logger,
+    required this.chunkStore,
+    required this.uploadSessionService,
+    required this.connectivityMonitor,
+    required this.backgroundTaskManager,
+  });
+
+  final Logger logger;
+  final ChunkPersistenceService chunkStore;
+  final UploadSessionService uploadSessionService;
+  final ConnectivityMonitor connectivityMonitor;
+  final BackgroundTaskManager backgroundTaskManager;
+
+  UploadSession? _activeSession;
+  bool _isUploading = false;
+  StreamSubscription<RecordingChunk>? _chunkSubscription;
+  StreamSubscription<bool>? _onlineSubscription;
+  bool _hasResumedBacklog = false;
+
+  void bindToRecorder(Stream<RecordingChunk> chunkStream) {
+    _chunkSubscription?.cancel();
+    _chunkSubscription = chunkStream.listen((chunk) {
+      logger.d('Chunk received from recorder: ${chunk.id}');
+      _uploadPendingChunks();
+    });
+    _onlineSubscription ??= connectivityMonitor.onlineStream.listen((online) {
+      if (online) {
+        _uploadPendingChunks();
+      }
+    });
+  }
+
+  Future<void> startSession(UploadSession session) async {
+    _activeSession = session;
+    await backgroundTaskManager.ensureServiceRunning();
+    await _uploadPendingChunks();
+  }
+
+  Future<void> stopSession() async {
+    _activeSession = null;
+    final remaining = await chunkStore.pendingChunks();
+    if (remaining.isEmpty) {
+      await backgroundTaskManager.stopService();
+    }
+  }
+
+  Future<void> resumePendingBacklog() async {
+    if (_hasResumedBacklog) {
+      return;
+    }
+    _hasResumedBacklog = true;
+    final pending = await chunkStore.pendingChunks();
+    if (pending.isEmpty) {
+      return;
+    }
+    await backgroundTaskManager.ensureServiceRunning();
+    await _uploadPendingChunks();
+  }
+
+  Future<void> _uploadPendingChunks() async {
+    if (_isUploading) return;
+    _isUploading = true;
+    try {
+      final chunks = await chunkStore.pendingChunks();
+      if (chunks.isEmpty) {
+        return;
+      }
+      if (_activeSession != null) {
+        chunks.sort((a, b) {
+          final aActive = a.sessionId == _activeSession!.sessionId;
+          final bActive = b.sessionId == _activeSession!.sessionId;
+          if (aActive != bActive) {
+            return aActive ? -1 : 1;
+          }
+          return a.createdAt.compareTo(b.createdAt);
+        });
+      }
+      for (final chunk in chunks) {
+        await _uploadChunk(chunk);
+      }
+      final remaining = await chunkStore.pendingChunks();
+      if (remaining.isEmpty && _activeSession == null) {
+        await backgroundTaskManager.stopService();
+      }
+    } finally {
+      _isUploading = false;
+    }
+  }
+
+  Future<void> _uploadChunk(RecordingChunk chunk) async {
+    try {
+      final presigned = await uploadSessionService.requestPresignedUrl(
+        chunk.sessionId,
+        chunk.sequence,
+      );
+      final file = File(chunk.filePath);
+      if (!await file.exists()) {
+        logger.w('Chunk file missing on disk: ${chunk.filePath}');
+        await chunkStore.deleteChunk(chunk.id);
+        return;
+      }
+      final bytes = await file.readAsBytes();
+      await uploadSessionService.uploadChunk(
+        presigned.url,
+        bytes,
+        headers: presigned.headers,
+      );
+      await uploadSessionService.notifyChunkUploaded(
+        chunk.sessionId,
+        chunk.sequence,
+      );
+      await chunkStore.markUploaded(chunk.id);
+      await chunkStore.deleteChunk(chunk.id);
+      logger.i('Uploaded chunk ${chunk.id}');
+    } catch (error, stackTrace) {
+      logger.w('Failed to upload chunk ${chunk.id}', error, stackTrace);
+      await chunkStore.incrementRetry(chunk.id);
+    }
+  }
+}

--- a/ai-scribe-copilot/lib/core/services/connectivity_monitor.dart
+++ b/ai-scribe-copilot/lib/core/services/connectivity_monitor.dart
@@ -1,0 +1,31 @@
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+
+import '../../utils/logger.dart';
+
+class ConnectivityMonitor {
+  ConnectivityMonitor({required this.logger});
+
+  final Logger logger;
+  final _connectivity = Connectivity();
+  final _controller = StreamController<bool>.broadcast();
+
+  Stream<bool> get onlineStream => _controller.stream;
+
+  Future<void> initialize() async {
+    final initial = await _connectivity.checkConnectivity();
+    _controller.add(_isOnline(initial));
+    _connectivity.onConnectivityChanged.listen((event) {
+      final online = _isOnline(event);
+      logger.d('Connectivity changed: $online');
+      _controller.add(online);
+    });
+  }
+
+  bool _isOnline(ConnectivityResult result) {
+    return result == ConnectivityResult.mobile ||
+        result == ConnectivityResult.wifi ||
+        result == ConnectivityResult.ethernet;
+  }
+}

--- a/ai-scribe-copilot/lib/core/services/interruption_handler.dart
+++ b/ai-scribe-copilot/lib/core/services/interruption_handler.dart
@@ -1,0 +1,60 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+
+import '../../utils/logger.dart';
+
+enum InterruptionEventType { phoneCallStarted, phoneCallEnded, audioFocusLost, audioFocusGained }
+
+class InterruptionEvent {
+  InterruptionEvent({required this.type});
+
+  final InterruptionEventType type;
+}
+
+class InterruptionHandler {
+  InterruptionHandler({required this.logger});
+
+  final Logger logger;
+  static const _channel = MethodChannel('ai_scribe_copilot/mic');
+  static const _events = EventChannel('ai_scribe_copilot/interruption');
+  final _controller = StreamController<InterruptionEvent>.broadcast();
+
+  Stream<InterruptionEvent> get events => _controller.stream;
+
+  Future<void> initialize() async {
+    _events.receiveBroadcastStream().listen((dynamic event) {
+      final map = Map<String, dynamic>.from(event as Map);
+      final type = InterruptionEventType.values.firstWhere(
+        (e) => e.name == map['type'],
+        orElse: () => InterruptionEventType.audioFocusLost,
+      );
+      logger.d('Received interruption event: $type');
+      _controller.add(InterruptionEvent(type: type));
+    });
+  }
+
+  Future<void> setGain(double gain) async {
+    try {
+      await _channel.invokeMethod('setGain', {'gain': gain});
+    } on PlatformException catch (error, stackTrace) {
+      logger.w('Failed to set gain', error, stackTrace);
+    }
+  }
+
+  Future<void> requestAudioFocus() async {
+    try {
+      await _channel.invokeMethod('requestFocus');
+    } on PlatformException catch (error, stackTrace) {
+      logger.w('Failed to request audio focus', error, stackTrace);
+    }
+  }
+
+  Future<void> abandonAudioFocus() async {
+    try {
+      await _channel.invokeMethod('abandonFocus');
+    } on PlatformException catch (error, stackTrace) {
+      logger.w('Failed to abandon audio focus', error, stackTrace);
+    }
+  }
+}

--- a/ai-scribe-copilot/lib/core/services/patient_service.dart
+++ b/ai-scribe-copilot/lib/core/services/patient_service.dart
@@ -1,0 +1,36 @@
+import '../../utils/logger.dart';
+import '../models/patient.dart';
+import '../network/api_client.dart';
+import '../network/api_endpoints.dart';
+
+class PatientService {
+  PatientService({required this.apiClient, required this.logger});
+
+  final ApiClient apiClient;
+  final Logger logger;
+
+  Future<List<Patient>> fetchPatients(String userId) async {
+    final response = await apiClient.get(
+      ApiEndpoints.patients,
+      queryParameters: {'userId': userId},
+    );
+    final data = response['patients'] as List<dynamic>? ?? const [];
+    return data.map((e) => Patient.fromJson(Map<String, dynamic>.from(e as Map))).toList();
+  }
+
+  Future<Patient> addPatient({
+    required String name,
+    required DateTime? dateOfBirth,
+    required String? mrn,
+  }) async {
+    final response = await apiClient.post(
+      ApiEndpoints.addPatient,
+      data: {
+        'name': name,
+        if (dateOfBirth != null) 'dateOfBirth': dateOfBirth.toIso8601String(),
+        if (mrn != null) 'mrn': mrn,
+      },
+    );
+    return Patient.fromJson(Map<String, dynamic>.from(response['patient'] as Map));
+  }
+}

--- a/ai-scribe-copilot/lib/core/services/upload_session_service.dart
+++ b/ai-scribe-copilot/lib/core/services/upload_session_service.dart
@@ -1,0 +1,68 @@
+import '../../utils/logger.dart';
+import '../models/upload_session.dart';
+import '../network/api_client.dart';
+import '../network/api_endpoints.dart';
+
+class PresignedUrl {
+  PresignedUrl({required this.url, required this.headers});
+
+  final String url;
+  final Map<String, dynamic> headers;
+}
+
+class UploadSessionService {
+  UploadSessionService({required this.apiClient, required this.logger});
+
+  final ApiClient apiClient;
+  final Logger logger;
+
+  Future<UploadSession> startSession({
+    required String patientId,
+    required String userId,
+  }) async {
+    final response = await apiClient.post(
+      ApiEndpoints.startSession,
+      data: {
+        'patientId': patientId,
+        'userId': userId,
+      },
+    );
+    final sessionId = response['sessionId'] as String;
+    return UploadSession(
+      sessionId: sessionId,
+      patientId: patientId,
+      userId: userId,
+      startedAt: DateTime.now().toUtc(),
+    );
+  }
+
+  Future<PresignedUrl> requestPresignedUrl(String sessionId, int sequence) async {
+    final response = await apiClient.post(
+      ApiEndpoints.presignedUrl,
+      data: {
+        'sessionId': sessionId,
+        'sequence': sequence,
+      },
+    );
+    return PresignedUrl(
+      url: response['url'] as String,
+      headers: response['headers'] != null
+          ? Map<String, dynamic>.from(response['headers'] as Map)
+          : const {},
+    );
+  }
+
+  Future<void> uploadChunk(String url, List<int> bytes, {Map<String, dynamic>? headers}) async {
+    await apiClient.putRaw(url, data: bytes, headers: headers);
+  }
+
+  Future<void> notifyChunkUploaded(String sessionId, int sequence) async {
+    await apiClient.post(
+      ApiEndpoints.notifyChunkUploaded,
+      data: {
+        'sessionId': sessionId,
+        'sequence': sequence,
+      },
+    );
+  }
+}

--- a/ai-scribe-copilot/lib/features/home/home_screen.dart
+++ b/ai-scribe-copilot/lib/features/home/home_screen.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+
+import '../patients/patient_list_screen.dart';
+import '../recording/screens/recording_screen.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('AI Scribe Copilot'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Capture every word even when the day gets chaotic.',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: 24),
+            FilledButton.icon(
+              onPressed: () async {
+                final patient = await Navigator.of(context).push(MaterialPageRoute(
+                  builder: (_) => const PatientListScreen(),
+                ));
+                if (patient != null && context.mounted) {
+                  await Navigator.of(context).push(MaterialPageRoute(
+                    builder: (_) => RecordingScreen(patient: patient),
+                  ));
+                }
+              },
+              icon: const Icon(Icons.mic),
+              label: const Text('Start new consultation'),
+            ),
+            const SizedBox(height: 12),
+            OutlinedButton.icon(
+              onPressed: () {
+                Navigator.of(context).push(MaterialPageRoute(
+                  builder: (_) => const PatientListScreen(viewSessionsOnly: true),
+                ));
+              },
+              icon: const Icon(Icons.people_alt_outlined),
+              label: const Text('Patients & history'),
+            ),
+            const Spacer(),
+            Text(
+              'The recorder is resilient to network drops, phone calls, and backgrounding. Keep caring for patients—we'll keep recording.',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/ai-scribe-copilot/lib/features/patients/patient_list_screen.dart
+++ b/ai-scribe-copilot/lib/features/patients/patient_list_screen.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/models/patient.dart';
+import '../../core/services/patient_service.dart';
+import '../../shared/providers.dart';
+
+final _patientListProvider = FutureProvider<List<Patient>>((ref) async {
+  final patientService = ref.watch(patientServiceProvider);
+  const demoUserId = 'demo-user';
+  return patientService.fetchPatients(demoUserId);
+});
+
+class PatientListScreen extends ConsumerWidget {
+  const PatientListScreen({super.key, this.viewSessionsOnly = false});
+
+  final bool viewSessionsOnly;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final patients = ref.watch(_patientListProvider);
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(viewSessionsOnly ? 'Patient History' : 'Select Patient'),
+      ),
+      body: patients.when(
+        data: (data) => ListView.separated(
+          itemBuilder: (context, index) {
+            final patient = data[index];
+            return ListTile(
+              title: Text(patient.name),
+              subtitle: patient.dateOfBirth != null
+                  ? Text('DOB: ${patient.dateOfBirth!.toLocal().toShortString()}')
+                  : null,
+              trailing: viewSessionsOnly ? const Icon(Icons.chevron_right) : null,
+              onTap: viewSessionsOnly
+                  ? () {
+                      // Future enhancement: navigate to sessions list.
+                    }
+                  : () => Navigator.of(context).pop(patient),
+            );
+          },
+          separatorBuilder: (_, __) => const Divider(height: 1),
+          itemCount: data.length,
+        ),
+        error: (error, stackTrace) => Center(
+          child: Text('Failed to load patients: $error'),
+        ),
+        loading: () => const Center(child: CircularProgressIndicator()),
+      ),
+      floatingActionButton: viewSessionsOnly
+          ? null
+          : FloatingActionButton.extended(
+              onPressed: () {
+                _showAddPatientDialog(context, ref);
+              },
+              icon: const Icon(Icons.person_add_alt_1),
+              label: const Text('Add patient'),
+            ),
+    );
+  }
+
+  Future<void> _showAddPatientDialog(BuildContext context, WidgetRef ref) async {
+    final nameController = TextEditingController();
+    final mrnController = TextEditingController();
+    DateTime? dob;
+    final formKey = GlobalKey<FormState>();
+    await showDialog<void>(
+      context: context,
+      builder: (dialogContext) {
+        return StatefulBuilder(
+          builder: (context, setState) {
+            return AlertDialog(
+              title: const Text('New patient'),
+              content: Form(
+                key: formKey,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    TextFormField(
+                      controller: nameController,
+                      decoration: const InputDecoration(labelText: 'Full name'),
+                      validator: (value) =>
+                          value == null || value.isEmpty ? 'Name required' : null,
+                    ),
+                    const SizedBox(height: 12),
+                    TextFormField(
+                      controller: mrnController,
+                      decoration: const InputDecoration(labelText: 'MRN (optional)'),
+                    ),
+                    const SizedBox(height: 12),
+                    Row(
+                      children: [
+                        Text(dob == null
+                            ? 'DOB not set'
+                            : 'DOB: ${dob!.toLocal().toShortString()}'),
+                        const Spacer(),
+                        TextButton(
+                          onPressed: () async {
+                            final now = DateTime.now();
+                            final selected = await showDatePicker(
+                              context: context,
+                              initialDate: DateTime(now.year - 30),
+                              firstDate: DateTime(now.year - 120),
+                              lastDate: now,
+                            );
+                            if (selected != null) {
+                              setState(() {
+                                dob = selected;
+                              });
+                            }
+                          },
+                          child: const Text('Set DOB'),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('Cancel'),
+                ),
+                FilledButton(
+                  onPressed: () async {
+                    if (formKey.currentState?.validate() ?? false) {
+                      final patientService = ref.read(patientServiceProvider);
+                      await patientService.addPatient(
+                        name: nameController.text,
+                        dateOfBirth: dob,
+                        mrn: mrnController.text.isEmpty ? null : mrnController.text,
+                      );
+                      ref.invalidate(_patientListProvider);
+                      if (context.mounted) {
+                        Navigator.of(context).pop();
+                      }
+                    }
+                  },
+                  child: const Text('Save'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+  }
+}
+
+extension on DateTime {
+  String toShortString() => '${year.toString().padLeft(4, '0')}-${month.toString().padLeft(2, '0')}-${day.toString().padLeft(2, '0')}';
+}

--- a/ai-scribe-copilot/lib/features/recording/controllers/recording_controller.dart
+++ b/ai-scribe-copilot/lib/features/recording/controllers/recording_controller.dart
@@ -1,0 +1,146 @@
+import 'dart:async';
+
+import 'package:battery_plus/battery_plus.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+import '../../../core/models/upload_session.dart';
+import '../../../core/services/audio_recorder_service.dart';
+import '../../../core/services/chunk_uploader.dart';
+import '../../../core/services/connectivity_monitor.dart';
+import '../../../core/services/interruption_handler.dart';
+import '../../../core/services/upload_session_service.dart';
+import '../../../shared/providers.dart';
+import '../../../utils/logger.dart';
+import '../state/recording_state.dart';
+
+final recordingControllerProvider =
+    StateNotifierProvider<RecordingController, RecordingState>(
+  (ref) {
+    final recorder = ref.watch(audioRecorderServiceProvider);
+    final uploader = ref.watch(chunkUploaderProvider);
+    final uploadService = ref.watch(uploadSessionServiceProvider);
+    final connectivity = ref.watch(connectivityMonitorProvider);
+    final interruption = ref.watch(interruptionHandlerProvider);
+    final logger = ref.watch(loggerProvider);
+    final controller = RecordingController(
+      recorder: recorder,
+      uploader: uploader,
+      uploadSessionService: uploadService,
+      connectivityMonitor: connectivity,
+      interruptionHandler: interruption,
+      logger: logger,
+    );
+    uploader.bindToRecorder(recorder.chunkStream);
+    return controller;
+  },
+);
+
+class RecordingController extends StateNotifier<RecordingState> {
+  RecordingController({
+    required this.recorder,
+    required this.uploader,
+    required this.uploadSessionService,
+    required this.connectivityMonitor,
+    required this.interruptionHandler,
+    required this.logger,
+  }) : super(const RecordingState()) {
+    _battery = Battery();
+    _connectivitySub = connectivityMonitor.onlineStream.listen((online) {
+      state = state.copyWith(
+        networkStatus: online ? NetworkStatus.online : NetworkStatus.offline,
+      );
+    });
+    _interruptionSub = interruptionHandler.events.listen((event) {
+      recorder.handleInterruption(event);
+    });
+    _tickTimer = Timer.periodic(const Duration(seconds: 1), _onTick);
+  }
+
+  final AudioRecorderService recorder;
+  final ChunkUploader uploader;
+  final UploadSessionService uploadSessionService;
+  final ConnectivityMonitor connectivityMonitor;
+  final InterruptionHandler interruptionHandler;
+  final Logger logger;
+
+  late final Battery _battery;
+  StreamSubscription<bool>? _connectivitySub;
+  StreamSubscription? _interruptionSub;
+  Timer? _tickTimer;
+  UploadSession? _session;
+  DateTime? _startedAt;
+
+  Future<void> start(String patientId, String patientName, String userId) async {
+    state = state.copyWith(lifecycle: RecordingLifecycle.preparing, patientName: patientName);
+    try {
+      final micStatus = await Permission.microphone.request();
+      if (!micStatus.isGranted) {
+        state = state.copyWith(
+          lifecycle: RecordingLifecycle.error,
+          errorMessage: 'Microphone permission is required to record.',
+        );
+        return;
+      }
+      final batteryLevel = await _battery.batteryLevel;
+      state = state.copyWith(
+        batteryStatus: batteryLevel < 20 ? BatteryStatus.critical : BatteryStatus.healthy,
+      );
+      _session = await uploadSessionService.startSession(
+        patientId: patientId,
+        userId: userId,
+      );
+      state = state.copyWith(sessionId: _session!.sessionId);
+      await uploader.startSession(_session!);
+      await recorder.startRecording(_session!.sessionId, resetSequence: true);
+      state = state.copyWith(lifecycle: RecordingLifecycle.recording);
+      _startedAt = DateTime.now();
+    } catch (error, stackTrace) {
+      logger.e('Failed to start recording', error, stackTrace);
+      state = state.copyWith(
+        lifecycle: RecordingLifecycle.error,
+        errorMessage: error.toString(),
+      );
+    }
+  }
+
+  Future<void> pause() async {
+    if (!recorder.isRecording) return;
+    await recorder.stopRecording(clearSession: false);
+    state = state.copyWith(lifecycle: RecordingLifecycle.paused);
+  }
+
+  Future<void> resume() async {
+    final session = _session;
+    if (session == null) return;
+    await recorder.startRecording(session.sessionId);
+    state = state.copyWith(lifecycle: RecordingLifecycle.recording);
+  }
+
+  Future<void> stop() async {
+    await recorder.stopRecording();
+    await uploader.stopSession();
+    state = state.copyWith(
+      lifecycle: RecordingLifecycle.idle,
+      duration: Duration.zero,
+      sessionId: null,
+    );
+    _session = null;
+    _startedAt = null;
+  }
+
+  void _onTick(Timer timer) {
+    if (state.lifecycle == RecordingLifecycle.recording && _startedAt != null) {
+      final duration = DateTime.now().difference(_startedAt!);
+      state = state.copyWith(duration: duration);
+    }
+  }
+
+  @override
+  void dispose() {
+    _connectivitySub?.cancel();
+    _interruptionSub?.cancel();
+    _tickTimer?.cancel();
+    super.dispose();
+  }
+}

--- a/ai-scribe-copilot/lib/features/recording/screens/recording_screen.dart
+++ b/ai-scribe-copilot/lib/features/recording/screens/recording_screen.dart
@@ -1,0 +1,196 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/models/patient.dart';
+import '../controllers/recording_controller.dart';
+import '../state/recording_state.dart';
+import '../widgets/audio_waveform_view.dart';
+import '../widgets/recording_controls.dart';
+
+class RecordingScreen extends ConsumerStatefulWidget {
+  const RecordingScreen({super.key, required this.patient});
+
+  final Patient patient;
+
+  @override
+  ConsumerState<RecordingScreen> createState() => _RecordingScreenState();
+}
+
+class _RecordingScreenState extends ConsumerState<RecordingScreen> {
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(() async {
+      final controller = ref.read(recordingControllerProvider.notifier);
+      await controller.start(widget.patient.id, widget.patient.name, 'demo-user');
+    });
+  }
+
+  @override
+  void dispose() {
+    final controller = ref.read(recordingControllerProvider.notifier);
+    unawaited(controller.stop());
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(recordingControllerProvider);
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.patient.name),
+        actions: [
+          Padding(
+            padding: const EdgeInsets.only(right: 16),
+            child: Center(
+              child: Text(
+                _statusLabel(state.lifecycle),
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
+            ),
+          ),
+        ],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Card(
+              color: Theme.of(context).colorScheme.surfaceVariant,
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Consultation timer',
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                    const SizedBox(height: 12),
+                    Text(
+                      _formatDuration(state.duration),
+                      style: Theme.of(context)
+                          .textTheme
+                          .displaySmall
+                          ?.copyWith(fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(height: 8),
+                    Wrap(
+                      spacing: 12,
+                      children: [
+                        _Badge(
+                          icon: state.networkStatus == NetworkStatus.online
+                              ? Icons.wifi
+                              : Icons.wifi_off,
+                          label: state.networkStatus == NetworkStatus.online
+                              ? 'Streaming live'
+                              : 'Offline - queued',
+                          backgroundColor: state.networkStatus == NetworkStatus.online
+                              ? Colors.green.shade100
+                              : Colors.orange.shade100,
+                        ),
+                        if (state.batteryStatus != null)
+                          _Badge(
+                            icon: state.batteryStatus == BatteryStatus.healthy
+                                ? Icons.battery_full
+                                : Icons.battery_alert,
+                            label: state.batteryStatus == BatteryStatus.healthy
+                                ? 'Battery healthy'
+                                : 'Charge soon',
+                            backgroundColor:
+                                state.batteryStatus == BatteryStatus.healthy
+                                    ? Colors.blue.shade100
+                                    : Colors.red.shade100,
+                          ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            Expanded(
+              child: AudioWaveformView(
+                isRecording: state.lifecycle == RecordingLifecycle.recording,
+              ),
+            ),
+            const SizedBox(height: 16),
+            RecordingControls(
+              lifecycle: state.lifecycle,
+              onPause: () => ref.read(recordingControllerProvider.notifier).pause(),
+              onResume: () => ref.read(recordingControllerProvider.notifier).resume(),
+              onStop: () async {
+                await ref.read(recordingControllerProvider.notifier).stop();
+                if (context.mounted) {
+                  Navigator.of(context).pop();
+                }
+              },
+            ),
+            if (state.errorMessage != null) ...[
+              const SizedBox(height: 12),
+              Text(
+                state.errorMessage!,
+                style: TextStyle(color: Theme.of(context).colorScheme.error),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _statusLabel(RecordingLifecycle lifecycle) {
+    switch (lifecycle) {
+      case RecordingLifecycle.preparing:
+        return 'Preparing';
+      case RecordingLifecycle.recording:
+        return 'Recording';
+      case RecordingLifecycle.paused:
+        return 'Paused';
+      case RecordingLifecycle.error:
+        return 'Error';
+      case RecordingLifecycle.idle:
+        return 'Idle';
+    }
+  }
+
+  String _formatDuration(Duration duration) {
+    final minutes = duration.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final seconds = duration.inSeconds.remainder(60).toString().padLeft(2, '0');
+    final hours = duration.inHours.toString().padLeft(2, '0');
+    return '$hours:$minutes:$seconds';
+  }
+}
+
+class _Badge extends StatelessWidget {
+  const _Badge({
+    required this.icon,
+    required this.label,
+    required this.backgroundColor,
+  });
+
+  final IconData icon;
+  final String label;
+  final Color backgroundColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 16),
+          const SizedBox(width: 6),
+          Text(label),
+        ],
+      ),
+    );
+  }
+}

--- a/ai-scribe-copilot/lib/features/recording/state/recording_state.dart
+++ b/ai-scribe-copilot/lib/features/recording/state/recording_state.dart
@@ -1,0 +1,45 @@
+enum RecordingLifecycle { idle, preparing, recording, paused, error }
+
+enum NetworkStatus { online, offline }
+
+enum BatteryStatus { healthy, critical }
+
+class RecordingState {
+  const RecordingState({
+    this.lifecycle = RecordingLifecycle.idle,
+    this.duration = Duration.zero,
+    this.networkStatus = NetworkStatus.online,
+    this.batteryStatus,
+    this.sessionId,
+    this.patientName,
+    this.errorMessage,
+  });
+
+  final RecordingLifecycle lifecycle;
+  final Duration duration;
+  final NetworkStatus networkStatus;
+  final BatteryStatus? batteryStatus;
+  final String? sessionId;
+  final String? patientName;
+  final String? errorMessage;
+
+  RecordingState copyWith({
+    RecordingLifecycle? lifecycle,
+    Duration? duration,
+    NetworkStatus? networkStatus,
+    BatteryStatus? batteryStatus,
+    String? sessionId,
+    String? patientName,
+    String? errorMessage,
+  }) {
+    return RecordingState(
+      lifecycle: lifecycle ?? this.lifecycle,
+      duration: duration ?? this.duration,
+      networkStatus: networkStatus ?? this.networkStatus,
+      batteryStatus: batteryStatus ?? this.batteryStatus,
+      sessionId: sessionId ?? this.sessionId,
+      patientName: patientName ?? this.patientName,
+      errorMessage: errorMessage ?? this.errorMessage,
+    );
+  }
+}

--- a/ai-scribe-copilot/lib/features/recording/widgets/audio_waveform_view.dart
+++ b/ai-scribe-copilot/lib/features/recording/widgets/audio_waveform_view.dart
@@ -1,0 +1,74 @@
+import 'package:audio_waveforms/audio_waveforms.dart';
+import 'package:flutter/material.dart';
+
+class AudioWaveformView extends StatefulWidget {
+  const AudioWaveformView({super.key, required this.isRecording});
+
+  final bool isRecording;
+
+  @override
+  State<AudioWaveformView> createState() => _AudioWaveformViewState();
+}
+
+class _AudioWaveformViewState extends State<AudioWaveformView> {
+  late final RecorderController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = RecorderController();
+    if (widget.isRecording) {
+      _controller.refresh();
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant AudioWaveformView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.isRecording && !oldWidget.isRecording) {
+      _controller.refresh();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(16),
+        color: Theme.of(context).colorScheme.surfaceVariant,
+      ),
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Live waveform',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 12),
+          Expanded(
+            child: AudioWaveforms(
+              size: const Size(double.infinity, double.infinity),
+              recorderController: _controller,
+              waveStyle: const WaveStyle(
+                waveColor: Colors.blueAccent,
+                extendWaveform: true,
+                showMiddleLine: false,
+              ),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            widget.isRecording
+                ? 'Streaming in real time. Interruptions are automatically recovered.'
+                : 'Paused. Resume when ready.',
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/ai-scribe-copilot/lib/features/recording/widgets/recording_controls.dart
+++ b/ai-scribe-copilot/lib/features/recording/widgets/recording_controls.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+
+import '../state/recording_state.dart';
+
+class RecordingControls extends StatelessWidget {
+  const RecordingControls({
+    super.key,
+    required this.lifecycle,
+    required this.onPause,
+    required this.onResume,
+    required this.onStop,
+  });
+
+  final RecordingLifecycle lifecycle;
+  final VoidCallback onPause;
+  final VoidCallback onResume;
+  final Future<void> Function() onStop;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: FilledButton.icon(
+            onPressed: lifecycle == RecordingLifecycle.recording ? onPause : onResume,
+            icon: Icon(
+              lifecycle == RecordingLifecycle.recording
+                  ? Icons.pause
+                  : Icons.play_arrow,
+            ),
+            label: Text(lifecycle == RecordingLifecycle.recording ? 'Pause' : 'Resume'),
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: OutlinedButton.icon(
+            onPressed: () async {
+              await onStop();
+            },
+            icon: const Icon(Icons.stop),
+            label: const Text('Finish & sync'),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/ai-scribe-copilot/lib/main.dart
+++ b/ai-scribe-copilot/lib/main.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+
+import 'bootstrap.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await bootstrap();
+}

--- a/ai-scribe-copilot/lib/shared/providers.dart
+++ b/ai-scribe-copilot/lib/shared/providers.dart
@@ -1,0 +1,73 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../core/network/api_client.dart';
+import '../core/services/audio_recorder_service.dart';
+import '../core/services/background_task_manager.dart';
+import '../core/services/chunk_persistence_service.dart';
+import '../core/services/chunk_uploader.dart';
+import '../core/services/connectivity_monitor.dart';
+import '../core/services/interruption_handler.dart';
+import '../core/services/patient_service.dart';
+import '../core/services/upload_session_service.dart';
+import '../utils/logger.dart';
+import '../utils/theme.dart';
+
+final themeProvider = Provider<AppTheme>((ref) => createTheme());
+
+Future<List<Override>> buildOverrides() async {
+  final logger = Logger();
+  final apiClient = ApiClient(logger: logger);
+  final chunkStore = ChunkPersistenceService(logger: logger);
+  await chunkStore.ensureInitialized();
+  final backgroundTaskManager = BackgroundTaskManager(logger: logger);
+  await backgroundTaskManager.initialize();
+  final connectivityMonitor = ConnectivityMonitor(logger: logger);
+  await connectivityMonitor.initialize();
+  final interruptionHandler = InterruptionHandler(logger: logger);
+  await interruptionHandler.initialize();
+  final audioRecorderService = AudioRecorderService(
+    logger: logger,
+    chunkPersistenceService: chunkStore,
+    interruptionHandler: interruptionHandler,
+  );
+  await audioRecorderService.initialize();
+  final uploadSessionService = UploadSessionService(
+    apiClient: apiClient,
+    logger: logger,
+  );
+  final chunkUploader = ChunkUploader(
+    logger: logger,
+    chunkStore: chunkStore,
+    uploadSessionService: uploadSessionService,
+    connectivityMonitor: connectivityMonitor,
+    backgroundTaskManager: backgroundTaskManager,
+  );
+  await chunkUploader.resumePendingBacklog();
+  final patientService = PatientService(
+    apiClient: apiClient,
+    logger: logger,
+  );
+  return [
+    apiClientProvider.overrideWithValue(apiClient),
+    loggerProvider.overrideWithValue(logger),
+    chunkStoreProvider.overrideWithValue(chunkStore),
+    backgroundTaskManagerProvider.overrideWithValue(backgroundTaskManager),
+    connectivityMonitorProvider.overrideWithValue(connectivityMonitor),
+    interruptionHandlerProvider.overrideWithValue(interruptionHandler),
+    audioRecorderServiceProvider.overrideWithValue(audioRecorderService),
+    uploadSessionServiceProvider.overrideWithValue(uploadSessionService),
+    chunkUploaderProvider.overrideWithValue(chunkUploader),
+    patientServiceProvider.overrideWithValue(patientService),
+  ];
+}
+
+final loggerProvider = Provider<Logger>((ref) => throw UnimplementedError());
+final apiClientProvider = Provider<ApiClient>((ref) => throw UnimplementedError());
+final chunkStoreProvider = Provider<ChunkPersistenceService>((ref) => throw UnimplementedError());
+final backgroundTaskManagerProvider = Provider<BackgroundTaskManager>((ref) => throw UnimplementedError());
+final connectivityMonitorProvider = Provider<ConnectivityMonitor>((ref) => throw UnimplementedError());
+final interruptionHandlerProvider = Provider<InterruptionHandler>((ref) => throw UnimplementedError());
+final audioRecorderServiceProvider = Provider<AudioRecorderService>((ref) => throw UnimplementedError());
+final uploadSessionServiceProvider = Provider<UploadSessionService>((ref) => throw UnimplementedError());
+final chunkUploaderProvider = Provider<ChunkUploader>((ref) => throw UnimplementedError());
+final patientServiceProvider = Provider<PatientService>((ref) => throw UnimplementedError());

--- a/ai-scribe-copilot/lib/utils/logger.dart
+++ b/ai-scribe-copilot/lib/utils/logger.dart
@@ -1,0 +1,19 @@
+import 'dart:developer' as developer;
+
+class Logger {
+  void d(String message) {
+    developer.log(message, name: 'DEBUG');
+  }
+
+  void i(String message) {
+    developer.log(message, name: 'INFO');
+  }
+
+  void w(String message, [Object? error, StackTrace? stackTrace]) {
+    developer.log(message, name: 'WARN', error: error, stackTrace: stackTrace);
+  }
+
+  void e(String message, [Object? error, StackTrace? stackTrace]) {
+    developer.log(message, name: 'ERROR', error: error, stackTrace: stackTrace);
+  }
+}

--- a/ai-scribe-copilot/lib/utils/theme.dart
+++ b/ai-scribe-copilot/lib/utils/theme.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class AppTheme {
+  AppTheme({required this.light, required this.dark});
+
+  final ThemeData light;
+  final ThemeData dark;
+}
+
+AppTheme createTheme() {
+  final colorScheme = ColorScheme.fromSeed(seedColor: const Color(0xFF0057B8));
+  final darkColorScheme = ColorScheme.fromSeed(
+    seedColor: const Color(0xFF00A1D6),
+    brightness: Brightness.dark,
+  );
+  return AppTheme(
+    light: ThemeData(
+      colorScheme: colorScheme,
+      useMaterial3: true,
+      appBarTheme: const AppBarTheme(centerTitle: false),
+    ),
+    dark: ThemeData(
+      colorScheme: darkColorScheme,
+      useMaterial3: true,
+      appBarTheme: const AppBarTheme(centerTitle: false),
+    ),
+  );
+}


### PR DESCRIPTION
## Summary
- build a Flutter application shell with Riverpod wiring, theming, and feature screens for launching background-safe recording sessions
- implement recording, chunk persistence, retrying uploads, and patient management services that queue audio during interruptions and recover after restarts
- add Android and iOS native bridges for audio focus, gain control, and interruption reporting while enabling required background permissions

## Testing
- not run (Flutter/Dart tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6860022d8832c9cb4d28b4a08eb77