### PR TITLE
Add runtime configurable API base URL

### DIFF
--- a/ai-scribe-copilot/README.md
+++ b/ai-scribe-copilot/README.md
@@ -56,24 +56,27 @@ A Flutter app that doctors can trust with their patient consultations. The app r
 
 4. **Run the app**
    ```bash
-   # Android
-   flutter run
-   
-   # iOS
-   flutter run -d ios
+   # Android (emulator connects to 10.0.2.2 by default)
+   flutter run --dart-define=API_BASE_URL=http://10.0.2.2:3000/api
+
+   # iOS / macOS simulators default to localhost so the define is optional
+   flutter run --dart-define=API_BASE_URL=http://localhost:3000/api
    ```
+
+   If you deploy the backend elsewhere, update the `API_BASE_URL` define to
+   match the HTTPS endpoint, e.g. `https://api.example.com`.
 
 ## 📦 Build Instructions
 
 ### Android APK
 ```bash
-flutter build apk --release
+flutter build apk --release --dart-define=API_BASE_URL=https://your.api.example
 ```
 The APK will be available at `build/app/outputs/flutter-apk/app-release.apk`
 
 ### iOS
 ```bash
-flutter build ios --release
+flutter build ios --release --dart-define=API_BASE_URL=https://your.api.example
 ```
 
 ## 🧪 Test Scenarios

--- a/ai-scribe-copilot/lib/constants/api_constants.dart
+++ b/ai-scribe-copilot/lib/constants/api_constants.dart
@@ -1,6 +1,8 @@
+import '../core/config/app_config.dart';
+
 class ApiConstants {
-  // Base URL - Local development backend
-  static const String baseUrl = 'http://localhost:3000/api';
+  // Base URL - resolved dynamically depending on platform and env overrides
+  static String get baseUrl => AppConfig.apiBaseUrl;
   
   // Session Management Endpoints
   static const String uploadSession = '/v1/upload-session';

--- a/ai-scribe-copilot/lib/core/config/app_config.dart
+++ b/ai-scribe-copilot/lib/core/config/app_config.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/foundation.dart';
+
+/// Centralised runtime configuration for the app.
+///
+/// The backend base URL can be overridden at build time with the
+/// `--dart-define=API_BASE_URL=...` flag so that developers can point the
+/// mobile client at any environment (local docker, staging, production).
+///
+/// We also provide sensible defaults for the most common setups:
+///   * Android emulator -> `10.0.2.2`
+///   * iOS simulator / desktop / unit tests -> `localhost`
+///   * Web builds -> `localhost`
+class AppConfig {
+  const AppConfig._();
+
+  static String get apiBaseUrl {
+    const override = String.fromEnvironment('API_BASE_URL');
+    if (override.isNotEmpty) {
+      return override;
+    }
+    if (kIsWeb) {
+      return 'http://localhost:3000/api';
+    }
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+        return 'http://10.0.2.2:3000/api';
+      case TargetPlatform.iOS:
+      case TargetPlatform.macOS:
+      case TargetPlatform.windows:
+      case TargetPlatform.linux:
+        return 'http://localhost:3000/api';
+      case TargetPlatform.fuchsia:
+        return 'http://localhost:3000/api';
+    }
+  }
+}

--- a/ai-scribe-copilot/lib/core/network/api_client.dart
+++ b/ai-scribe-copilot/lib/core/network/api_client.dart
@@ -3,13 +3,13 @@ import 'dart:convert';
 import 'package:dio/dio.dart';
 
 import '../../utils/logger.dart';
-import 'api_endpoints.dart';
+import '../config/app_config.dart';
 
 class ApiClient {
   ApiClient({required this.logger}) {
     _dio = Dio(
       BaseOptions(
-        baseUrl: ApiEndpoints.baseUrl,
+        baseUrl: AppConfig.apiBaseUrl,
         connectTimeout: const Duration(seconds: 10),
         receiveTimeout: const Duration(seconds: 30),
       ),

--- a/ai-scribe-copilot/lib/core/network/api_endpoints.dart
+++ b/ai-scribe-copilot/lib/core/network/api_endpoints.dart
@@ -1,5 +1,7 @@
+import '../config/app_config.dart';
+
 class ApiEndpoints {
-  static const String baseUrl = 'https://api.medical-scribe.example';
+  static String get baseUrl => AppConfig.apiBaseUrl;
 
   static const String startSession = '/v1/upload-session';
   static const String presignedUrl = '/v1/get-presigned-url';


### PR DESCRIPTION
## Summary
- add an `AppConfig` helper that resolves the API base URL from `--dart-define` overrides with platform-aware defaults
- switch the API client and endpoint helpers to consume the shared configuration so mobile builds point at the correct backend out of the box
- document how to pass the backend URL when running and building Flutter apps

## Testing
- Not run (Flutter SDK is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d6a977025c832cafd9162ca973cb43