### PR TITLE
Fix background service startup invocation

### DIFF
--- a/ai-scribe-copilot/lib/core/services/background_task_manager.dart
+++ b/ai-scribe-copilot/lib/core/services/background_task_manager.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:flutter_background_service/flutter_background_service.dart';
-import 'package:flutter_background_service_android/flutter_background_service_android.dart';
 
 import '../../utils/logger.dart';
 
@@ -29,7 +28,7 @@ class BackgroundTaskManager {
     final isRunning = await _service.isRunning();
     if (!isRunning) {
       logger.d('Starting background service');
-      await _service.startService();
+      _service.startService();
     }
   }
 


### PR DESCRIPTION
## Summary
- avoid awaiting the background service start call that returns void
- remove the redundant Android-specific service import

## Testing
- not run (flutter CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6b0db31f4832c898f29dbbab899ef