### PR TITLE
Fix analyzer issues and clean up unused imports

### DIFF
--- a/ai-scribe-copilot/lib/app.dart
+++ b/ai-scribe-copilot/lib/app.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'features/home/home_screen.dart';
 import 'shared/providers.dart';
-import 'utils/theme.dart';
 
 class AiScribeApp extends ConsumerWidget {
   const AiScribeApp({super.key});

--- a/ai-scribe-copilot/lib/core/services/background_task_manager.dart
+++ b/ai-scribe-copilot/lib/core/services/background_task_manager.dart
@@ -34,7 +34,7 @@ class BackgroundTaskManager {
 
   Future<void> stopService() async {
     if (await _service.isRunning()) {
-      await _service.invoke('stopService');
+      _service.invoke('stopService');
     }
   }
 

--- a/ai-scribe-copilot/lib/features/patients/patient_list_screen.dart
+++ b/ai-scribe-copilot/lib/features/patients/patient_list_screen.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/models/patient.dart';
-import '../../core/services/patient_service.dart';
 import '../../shared/providers.dart';
 
 final _patientListProvider = FutureProvider<List<Patient>>((ref) async {

--- a/ai-scribe-copilot/lib/features/recording/screens/recording_screen.dart
+++ b/ai-scribe-copilot/lib/features/recording/screens/recording_screen.dart
@@ -58,7 +58,7 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             Card(
-              color: Theme.of(context).colorScheme.surfaceVariant,
+              color: Theme.of(context).colorScheme.surfaceContainerHighest,
               child: Padding(
                 padding: const EdgeInsets.all(16),
                 child: Column(

--- a/ai-scribe-copilot/lib/features/recording/widgets/audio_waveform_view.dart
+++ b/ai-scribe-copilot/lib/features/recording/widgets/audio_waveform_view.dart
@@ -35,11 +35,12 @@ class _AudioWaveformViewState extends State<AudioWaveformView> {
     _controller.dispose();
     super.dispose();
   }
+  @override
   Widget build(BuildContext context) {
     return Container(
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(16),
-        color: Theme.of(context).colorScheme.surfaceVariant,
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
       ),
       padding: const EdgeInsets.all(16),
       child: Column(

--- a/ai-scribe-copilot/lib/services/background_service.dart
+++ b/ai-scribe-copilot/lib/services/background_service.dart
@@ -1,12 +1,8 @@
 import 'dart:async';
-import 'dart:isolate';
 import 'package:flutter_background_service/flutter_background_service.dart';
 import 'package:flutter_background_service_android/flutter_background_service_android.dart';
-import 'package:flutter_background_service_ios/flutter_background_service_ios.dart';
-import 'package:permission_handler/permission_handler.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import '../constants/api_constants.dart';
-import 'audio_recording_service.dart';
 import 'api_service.dart';
 import 'local_storage_service.dart';
 
@@ -15,7 +11,6 @@ class BackgroundService {
   factory BackgroundService() => _instance;
   BackgroundService._internal();
 
-  final AudioRecordingService _audioService = AudioRecordingService();
   final ApiService _apiService = ApiService();
   final LocalStorageService _storageService = LocalStorageService();
   final Connectivity _connectivity = Connectivity();
@@ -88,8 +83,7 @@ class BackgroundService {
     service.on('update_notification').listen((event) {
       final title = event?['title'] as String? ?? 'AI Scribe Copilot';
       final content = event?['content'] as String? ?? 'Service running';
-      final isRecording = event?['isRecording'] as bool? ?? false;
-      
+
       if (service is AndroidServiceInstance) {
         service.setForegroundNotificationInfo(
           title: title,

--- a/ai-scribe-copilot/lib/services/interruption_handler.dart
+++ b/ai-scribe-copilot/lib/services/interruption_handler.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'package:flutter/services.dart';
-import 'package:permission_handler/permission_handler.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:battery_plus/battery_plus.dart';
 import '../models/recording_session.dart';

--- a/ai-scribe-copilot/lib/services/local_storage_service.dart
+++ b/ai-scribe-copilot/lib/services/local_storage_service.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sqflite/sqflite.dart';
 import 'package:path/path.dart';

--- a/ai-scribe-copilot/lib/widgets/audio_visualizer_widget.dart
+++ b/ai-scribe-copilot/lib/widgets/audio_visualizer_widget.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:math';
 import 'package:flutter/material.dart';
 import '../services/audio_recording_service.dart';
 

--- a/ai-scribe-copilot/test/widget_test.dart
+++ b/ai-scribe-copilot/test/widget_test.dart
@@ -5,7 +5,6 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:ai_scribe_copilot/app.dart';


### PR DESCRIPTION
## Summary
- stop awaiting the void background service invocation to satisfy analyzer
- remove unused imports and members across services, widgets, and tests
- replace deprecated color usage and annotate overrides in recording UI

## Testing
- flutter analyze *(fails: Flutter SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b68e2768832c84c066f7030c4531