### PR TITLE
Fix Gradle locking error on macOS

### DIFF
--- a/ai-scribe-copilot/.gitignore
+++ b/ai-scribe-copilot/.gitignore
@@ -43,3 +43,4 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+/backend/node_modules/

--- a/ai-scribe-copilot/README.md
+++ b/ai-scribe-copilot/README.md
@@ -89,7 +89,11 @@ If Android Studio or `flutter run` fails with a message similar to:
 Cannot lock file hash cache (.../android/.gradle/<version>/fileHashes) as it has already been locked by this process
 ```
 
-it usually means a previous Gradle process crashed and left a stale lock file.
+We now pin the Android build to Gradle **8.10.2**, which avoids a locking bug
+present in Gradle 8.12 on macOS. If you ran the project before this change, the
+old cache may still be present locally. In that case, or if you continue to see
+the error, it usually means a previous Gradle process crashed and left a stale
+lock file.
 
 1. Stop any running Gradle daemons:
    ```bash

--- a/ai-scribe-copilot/android/gradle/wrapper/gradle-wrapper.properties
+++ b/ai-scribe-copilot/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip


### PR DESCRIPTION
## Summary
- pin the Android Gradle wrapper to 8.10.2 to avoid the file hash lock bug seen on macOS
- document the pinned Gradle version in the troubleshooting guide
- ignore the backend node_modules directory so the cache is not re-added

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6c959b290832ca543cb67b18cb249