### PR TITLE
Replace waveform widget with lightweight custom painter

### DIFF
--- a/ai-scribe-copilot/lib/features/recording/widgets/audio_waveform_view.dart
+++ b/ai-scribe-copilot/lib/features/recording/widgets/audio_waveform_view.dart
@@ -1,4 +1,5 @@
-import 'package:audio_waveforms/audio_waveforms.dart';
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 
 class AudioWaveformView extends StatefulWidget {
@@ -10,15 +11,31 @@ class AudioWaveformView extends StatefulWidget {
   State<AudioWaveformView> createState() => _AudioWaveformViewState();
 }
 
-class _AudioWaveformViewState extends State<AudioWaveformView> {
-  late final RecorderController _controller;
+class _AudioWaveformViewState extends State<AudioWaveformView>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late List<double> _amplitudes;
+  final math.Random _random = math.Random();
 
   @override
   void initState() {
     super.initState();
-    _controller = RecorderController();
+    _amplitudes = _generateAmplitudes();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1200),
+    )..addStatusListener((status) {
+        if (!mounted || !widget.isRecording) {
+          return;
+        }
+        if (status == AnimationStatus.completed) {
+          setState(() {
+            _amplitudes = _generateAmplitudes();
+          });
+        }
+      });
     if (widget.isRecording) {
-      _controller.refresh();
+      _controller.repeat(reverse: true);
     }
   }
 
@@ -26,7 +43,12 @@ class _AudioWaveformViewState extends State<AudioWaveformView> {
   void didUpdateWidget(covariant AudioWaveformView oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.isRecording && !oldWidget.isRecording) {
-      _controller.refresh();
+      _amplitudes = _generateAmplitudes();
+      _controller
+        ..reset()
+        ..repeat(reverse: true);
+    } else if (!widget.isRecording && oldWidget.isRecording) {
+      _controller.stop();
     }
   }
 
@@ -35,12 +57,18 @@ class _AudioWaveformViewState extends State<AudioWaveformView> {
     _controller.dispose();
     super.dispose();
   }
+
+  List<double> _generateAmplitudes() {
+    return List<double>.generate(48, (_) => _random.nextDouble());
+  }
+
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return Container(
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(16),
-        color: Theme.of(context).colorScheme.surfaceContainerHighest,
+        color: theme.colorScheme.surfaceContainerHighest,
       ),
       padding: const EdgeInsets.all(16),
       child: Column(
@@ -48,18 +76,22 @@ class _AudioWaveformViewState extends State<AudioWaveformView> {
         children: [
           Text(
             'Live waveform',
-            style: Theme.of(context).textTheme.titleMedium,
+            style: theme.textTheme.titleMedium,
           ),
           const SizedBox(height: 12),
           Expanded(
-            child: AudioWaveforms(
-              size: const Size(double.infinity, double.infinity),
-              recorderController: _controller,
-              waveStyle: const WaveStyle(
-                waveColor: Colors.blueAccent,
-                extendWaveform: true,
-                showMiddleLine: false,
-              ),
+            child: AnimatedBuilder(
+              animation: _controller,
+              builder: (context, _) {
+                return CustomPaint(
+                  painter: _WaveformPainter(
+                    progress: widget.isRecording ? _controller.value : 0,
+                    amplitudes: _amplitudes,
+                    color: theme.colorScheme.primary,
+                    isRecording: widget.isRecording,
+                  ),
+                );
+              },
             ),
           ),
           const SizedBox(height: 8),
@@ -71,5 +103,59 @@ class _AudioWaveformViewState extends State<AudioWaveformView> {
         ],
       ),
     );
+  }
+}
+
+class _WaveformPainter extends CustomPainter {
+  _WaveformPainter({
+    required this.progress,
+    required this.amplitudes,
+    required this.color,
+    required this.isRecording,
+  });
+
+  final double progress;
+  final List<double> amplitudes;
+  final Color color;
+  final bool isRecording;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (amplitudes.isEmpty || size.width <= 0 || size.height <= 0) {
+      return;
+    }
+    final barCount = amplitudes.length;
+    final step = size.width / barCount;
+    final barWidth = step * 0.55;
+    final paint = Paint()
+      ..color = isRecording ? color : color.withOpacity(0.4)
+      ..strokeCap = StrokeCap.round
+      ..strokeWidth = barWidth;
+    final baseline = size.height / 2;
+    final animationPhase = progress * 2 * math.pi;
+
+    for (int i = 0; i < barCount; i++) {
+      final amplitude = amplitudes[i];
+      final oscillation = isRecording
+          ? (math.sin(animationPhase + i * 0.35) + 1) / 2
+          : 0.0;
+      final intensity = (0.25 + amplitude * 0.5 + oscillation * 0.35)
+          .clamp(0.0, 1.0);
+      final barHeight = size.height * intensity;
+      final x = step * i + step / 2;
+      canvas.drawLine(
+        Offset(x, baseline - barHeight / 2),
+        Offset(x, baseline + barHeight / 2),
+        paint,
+      );
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _WaveformPainter oldDelegate) {
+    return oldDelegate.progress != progress ||
+        oldDelegate.amplitudes != amplitudes ||
+        oldDelegate.color != color ||
+        oldDelegate.isRecording != isRecording;
   }
 }

--- a/ai-scribe-copilot/pubspec.lock
+++ b/ai-scribe-copilot/pubspec.lock
@@ -41,14 +41,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.0"
-  audio_waveforms:
-    dependency: "direct main"
-    description:
-      name: audio_waveforms
-      sha256: "658fef41bbab299184b65ba2fd749e8ec658c1f7d54a21f7cf97fa96b173b4ce"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.0"
   battery_plus:
     dependency: "direct main"
     description:

--- a/ai-scribe-copilot/pubspec.yaml
+++ b/ai-scribe-copilot/pubspec.yaml
@@ -68,9 +68,6 @@ dependencies:
   flutter_animate: ^4.5.0
   lottie: ^3.1.2
   
-  # Audio visualization
-  audio_waveforms: ^1.0.5
-  
   # Speech recognition (bonus feature) - disabled for now
   # speech_to_text: ^6.6.0
   


### PR DESCRIPTION
## Summary
- replace the audio waveform widget to use a lightweight custom painter animation instead of the audio_waveforms plugin
- drop the unused audio_waveforms dependency from pubspec.yaml and the lockfile

## Testing
- Not run (flutter tool not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6d75b2298832c97a6f89fb81c4f39