### PR TITLE
Annotate background service entry points

### DIFF
--- a/ai-scribe-copilot/lib/core/services/background_task_manager.dart
+++ b/ai-scribe-copilot/lib/core/services/background_task_manager.dart
@@ -38,6 +38,7 @@ class BackgroundTaskManager {
     }
   }
 
+  @pragma('vm:entry-point')
   static Future<void> _onStart(ServiceInstance service) async {
     if (service is AndroidServiceInstance) {
       service.setAsForegroundService();
@@ -51,6 +52,7 @@ class BackgroundTaskManager {
     });
   }
 
+  @pragma('vm:entry-point')
   static Future<bool> _onIosBackground(ServiceInstance service) async {
     return true;
   }


### PR DESCRIPTION
## Summary
- annotate the background service callbacks used by FlutterBackgroundService with `@pragma('vm:entry-point')`
- ensure the callbacks remain accessible when invoked from native code

## Testing
- not run (Flutter tooling is unavailable in the current environment)


------
https://chatgpt.com/codex/tasks/task_e_68d6e2d03758832cb747196582c92873