### PR TITLE
Annotate BackgroundTaskManager for native entry point

### DIFF
--- a/ai-scribe-copilot/lib/core/services/background_task_manager.dart
+++ b/ai-scribe-copilot/lib/core/services/background_task_manager.dart
@@ -4,6 +4,7 @@ import 'package:flutter_background_service/flutter_background_service.dart';
 
 import '../../utils/logger.dart';
 
+@pragma('vm:entry-point')
 class BackgroundTaskManager {
   BackgroundTaskManager({required this.logger});
 


### PR DESCRIPTION
## Summary
- mark BackgroundTaskManager with a vm:entry-point pragma so it can be accessed from native code
- ensure background task startup no longer triggers AOT entry point errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6e7b45fc0832c997b8e2c96c8e4f1