### PR TITLE
Increase API timeout and annotate background task entrypoint

### DIFF
--- a/ai-scribe-copilot/lib/core/network/api_client.dart
+++ b/ai-scribe-copilot/lib/core/network/api_client.dart
@@ -10,7 +10,7 @@ class ApiClient {
     _dio = Dio(
       BaseOptions(
         baseUrl: AppConfig.apiBaseUrl,
-        connectTimeout: const Duration(seconds: 10),
+        connectTimeout: const Duration(seconds: 30),
         receiveTimeout: const Duration(seconds: 30),
       ),
     );

--- a/ai-scribe-copilot/lib/core/services/background_task_manager.dart
+++ b/ai-scribe-copilot/lib/core/services/background_task_manager.dart
@@ -6,6 +6,7 @@ import '../../utils/logger.dart';
 
 @pragma('vm:entry-point')
 class BackgroundTaskManager {
+  @pragma('vm:entry-point')
   BackgroundTaskManager({required this.logger});
 
   final Logger logger;


### PR DESCRIPTION
## Summary
- raise the Dio client connection timeout to 30 seconds so patient requests have longer to complete
- mark the BackgroundTaskManager constructor as an entry point to satisfy native access requirements

## Testing
- flutter test *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6e9f49804832cb9eff993373f647d