### PR TITLE
Fix LocalStack volume directory configuration

### DIFF
--- a/ai-scribe-copilot/docker-compose.yml
+++ b/ai-scribe-copilot/docker-compose.yml
@@ -26,11 +26,11 @@ services:
     environment:
       - SERVICES=s3
       - DEBUG=1
-      - DATA_DIR=/tmp/localstack/data
+      - LOCALSTACK_VOLUME_DIR=/var/lib/localstack
       - DOCKER_HOST=unix:///var/run/docker.sock
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
-      - "./localstack-data:/tmp/localstack"
+      - "./localstack-data:/var/lib/localstack"
     networks:
       - ai-scribe-network
 


### PR DESCRIPTION
## Summary
- adjust LocalStack volume configuration to use /var/lib/localstack
- set LOCALSTACK_VOLUME_DIR to avoid cleanup failures during startup

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6ff60ae9c832cba3c23e8537bcbf2