### PR TITLE
Add IPv6-friendly API base URL configuration

### DIFF
--- a/ai-scribe-copilot/README.md
+++ b/ai-scribe-copilot/README.md
@@ -70,6 +70,15 @@ A Flutter app that doctors can trust with their patient consultations. The app r
    > computer's LAN IP address so the phone can reach the backend running on
    > your machine, then rerun the `flutter run --dart-define=API_BASE_URL=...`
    > command. Example: `flutter run --dart-define=API_BASE_URL=http://192.168.1.50:3000/api`.
+   >
+   > For IPv6 networks you can skip the square bracket syntax entirely by
+   > providing the URL components separately:
+   > ```bash
+   > flutter run \
+   >   --dart-define=API_HOST=2409:40d4:2405:9e6b:8000:: \
+   >   --dart-define=API_PORT=3000 \
+   >   --dart-define=API_PATH=api
+   > ```
 
 ## 📦 Build Instructions
 
@@ -128,7 +137,8 @@ This usually means the mobile client could not reach the backend REST API.
    `10.0.2.2` with the IP address of your development machine on the same Wi-Fi
    network, e.g. `flutter run --dart-define=API_BASE_URL=http://192.168.1.50:3000/api`.
 3. If the backend is running on another host or port, update the
-   `API_BASE_URL` define to match.
+   `API_BASE_URL` define (or the `API_HOST`/`API_PORT`/`API_PATH` components)
+   to match.
 
 After updating the URL, rebuild/restart the app so the new endpoint is picked
 up.

--- a/ai-scribe-copilot/lib/core/config/app_config.dart
+++ b/ai-scribe-copilot/lib/core/config/app_config.dart
@@ -6,6 +6,11 @@ import 'package:flutter/foundation.dart';
 /// `--dart-define=API_BASE_URL=...` flag so that developers can point the
 /// mobile client at any environment (local docker, staging, production).
 ///
+/// From the command line you can also specify the individual components of the
+/// API URL using `API_HOST`, `API_PORT`, `API_SCHEME` and `API_PATH`. This is
+/// particularly handy for IPv6 addresses where wrapping the host in square
+/// brackets correctly can be error prone.
+///
 /// We also provide sensible defaults for the most common setups:
 ///   * Android emulator -> `10.0.2.2`
 ///   * iOS simulator / desktop / unit tests -> `localhost`
@@ -13,15 +18,90 @@ import 'package:flutter/foundation.dart';
 class AppConfig {
   const AppConfig._();
 
-  static String get apiBaseUrl {
-    const override = String.fromEnvironment('API_BASE_URL');
-    if (override.isNotEmpty) {
-      return override;
+  static String get apiBaseUrl => _resolveBaseUrl(
+        baseOverride: const String.fromEnvironment('API_BASE_URL'),
+        hostOverride: const String.fromEnvironment('API_HOST'),
+        schemeOverride: const String.fromEnvironment('API_SCHEME'),
+        portOverride: const String.fromEnvironment('API_PORT'),
+        pathOverride: const String.fromEnvironment('API_PATH'),
+        platform: defaultTargetPlatform,
+        isWeb: kIsWeb,
+      );
+
+  @visibleForTesting
+  static String resolveBaseUrlForTest({
+    String baseOverride = '',
+    String hostOverride = '',
+    String schemeOverride = '',
+    String portOverride = '',
+    String pathOverride = '',
+    TargetPlatform platform = TargetPlatform.android,
+    bool isWeb = false,
+  }) {
+    return _resolveBaseUrl(
+      baseOverride: baseOverride,
+      hostOverride: hostOverride,
+      schemeOverride: schemeOverride,
+      portOverride: portOverride,
+      pathOverride: pathOverride,
+      platform: platform,
+      isWeb: isWeb,
+    );
+  }
+
+  static String _resolveBaseUrl({
+    required String baseOverride,
+    required String hostOverride,
+    required String schemeOverride,
+    required String portOverride,
+    required String pathOverride,
+    required TargetPlatform platform,
+    required bool isWeb,
+  }) {
+    final trimmedBaseOverride = baseOverride.trim();
+    if (trimmedBaseOverride.isNotEmpty) {
+      return trimmedBaseOverride;
     }
-    if (kIsWeb) {
+
+    final trimmedHostOverride = hostOverride.trim();
+    if (trimmedHostOverride.isNotEmpty) {
+      final trimmedSchemeOverride = schemeOverride.trim();
+      final scheme =
+          trimmedSchemeOverride.isEmpty ? 'http' : trimmedSchemeOverride;
+
+      final trimmedPortOverride = portOverride.trim();
+      final port = trimmedPortOverride.isEmpty
+          ? null
+          : int.tryParse(trimmedPortOverride);
+      if (trimmedPortOverride.isNotEmpty && port == null) {
+        throw FormatException(
+          'Invalid API_PORT "$trimmedPortOverride": expected an integer.',
+        );
+      }
+
+      final trimmedPathOverride = pathOverride.trim();
+      final pathSegments = trimmedPathOverride.isEmpty
+          ? const <String>[]
+          : trimmedPathOverride
+              .split('/')
+              .map((segment) => segment.trim())
+              .where((segment) => segment.isNotEmpty)
+              .toList(growable: false);
+
+      final uri = Uri(
+        scheme: scheme,
+        host: trimmedHostOverride,
+        port: port,
+        pathSegments: pathSegments,
+      );
+      return uri.toString();
+    }
+
+    if (isWeb) {
       return 'http://localhost:3000/api';
     }
-    switch (defaultTargetPlatform) {
+
+    switch (platform) {
       case TargetPlatform.android:
         return 'http://10.0.2.2:3000/api';
       case TargetPlatform.iOS:

--- a/ai-scribe-copilot/lib/features/patients/patient_list_screen.dart
+++ b/ai-scribe-copilot/lib/features/patients/patient_list_screen.dart
@@ -74,7 +74,9 @@ class PatientListScreen extends ConsumerWidget {
                       'The app could not reach the backend at $baseUrl.\n'
                       '• Make sure the API server is running (e.g. `docker-compose up -d`).\n'
                       '• If you are testing on a physical device, replace 10.0.2.2 with your computer\'s LAN IP and rebuild with:\n'
-                      '  flutter run --dart-define=API_BASE_URL=http://<your-ip>:3000/api',
+                      '  flutter run --dart-define=API_BASE_URL=http://<your-ip>:3000/api\n'
+                      '• On IPv6 networks you can provide the components separately instead:\n'
+                      '  flutter run --dart-define=API_HOST=<ipv6-host> --dart-define=API_PORT=3000 --dart-define=API_PATH=api',
                       style: theme.textTheme.bodyMedium,
                     ),
                     const SizedBox(height: 12),

--- a/ai-scribe-copilot/test/core/config/app_config_test.dart
+++ b/ai-scribe-copilot/test/core/config/app_config_test.dart
@@ -1,0 +1,79 @@
+import 'package:ai_scribe_copilot/core/config/app_config.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AppConfig.resolveBaseUrlForTest', () {
+    test('returns trimmed API_BASE_URL override when provided', () {
+      expect(
+        AppConfig.resolveBaseUrlForTest(
+          baseOverride: '  https://example.com/api  ',
+          platform: TargetPlatform.android,
+        ),
+        'https://example.com/api',
+      );
+    });
+
+    test('builds URI from IPv6 host components', () {
+      expect(
+        AppConfig.resolveBaseUrlForTest(
+          hostOverride: '2409:40d4:2405:9e6b:8000::',
+          portOverride: '3000',
+          pathOverride: 'api',
+          schemeOverride: 'http',
+        ),
+        'http://[2409:40d4:2405:9e6b:8000::]:3000/api',
+      );
+    });
+
+    test('normalises custom path segments', () {
+      expect(
+        AppConfig.resolveBaseUrlForTest(
+          hostOverride: 'api.example.com',
+          portOverride: '8080',
+          pathOverride: '/v1//patients/',
+          schemeOverride: 'https',
+        ),
+        'https://api.example.com:8080/v1/patients',
+      );
+    });
+
+    test('throws when API_PORT is not numeric', () {
+      expect(
+        () => AppConfig.resolveBaseUrlForTest(
+          hostOverride: 'api.example.com',
+          portOverride: 'abc',
+        ),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('falls back to localhost for web builds', () {
+      expect(
+        AppConfig.resolveBaseUrlForTest(
+          isWeb: true,
+          platform: TargetPlatform.android,
+        ),
+        'http://localhost:3000/api',
+      );
+    });
+
+    test('falls back to Android emulator defaults', () {
+      expect(
+        AppConfig.resolveBaseUrlForTest(
+          platform: TargetPlatform.android,
+        ),
+        'http://10.0.2.2:3000/api',
+      );
+    });
+
+    test('falls back to localhost for desktop platforms', () {
+      expect(
+        AppConfig.resolveBaseUrlForTest(
+          platform: TargetPlatform.windows,
+        ),
+        'http://localhost:3000/api',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- allow overriding the API base URL via separate API_HOST/API_PORT/API_PATH defines to better support IPv6 hosts
- surface the new configuration path in the README and network error helper copy
- add unit tests covering the new base URL resolution logic

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d70717d008832cadb2ff2e170d9651