### PR TITLE
Enable IPv6-friendly backend binding with IPv4 fallback

### DIFF
--- a/ai-scribe-copilot/README.md
+++ b/ai-scribe-copilot/README.md
@@ -54,6 +54,12 @@ A Flutter app that doctors can trust with their patient consultations. The app r
    docker-compose up -d
    ```
 
+   The mock server binds to IPv6 (`::`) by default so physical devices on
+   IPv6-only or dual-stack networks can reach it (the server automatically
+   falls back to IPv4 if IPv6 is unavailable). To force a specific interface,
+   set the `HOST` environment variable before launching the backend, e.g.
+   `HOST=0.0.0.0 npm start` for IPv4-only environments.
+
 4. **Run the app**
    ```bash
    # Android (emulator connects to 10.0.2.2 by default)


### PR DESCRIPTION
## Summary
- update the mock backend to bind to IPv6 by default with a graceful IPv4 fallback
- log the resolved listening address and provide a HOST override for advanced setups
- document the new binding behavior and HOST option in the README

## Testing
- node backend/server.js

------
https://chatgpt.com/codex/tasks/task_e_68d70afbe17c832cb0968942ea087412