### PR TITLE
Add WebSocket support for streaming notifications

### DIFF
--- a/ai-scribe-copilot/backend/package.json
+++ b/ai-scribe-copilot/backend/package.json
@@ -15,7 +15,8 @@
     "uuid": "^9.0.1",
     "body-parser": "^1.20.2",
     "helmet": "^7.1.0",
-    "morgan": "^1.10.0"
+    "morgan": "^1.10.0",
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "nodemon": "^3.0.2"


### PR DESCRIPTION
## Summary
- add the `ws` dependency to the backend container
- host a `/ws` WebSocket endpoint with heartbeat handling and graceful fallbacks
- broadcast session, chunk, patient, and transcription events to connected streaming clients

## Testing
- `npm install` *(fails: npm registry access is forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d79b4b0b84832cb78accceff7aaf98