### PR TITLE
Handle multipart and legacy presigned uploads

### DIFF
--- a/ai-scribe-copilot/lib/core/network/api_client.dart
+++ b/ai-scribe-copilot/lib/core/network/api_client.dart
@@ -50,16 +50,39 @@ class ApiClient {
     return _decode(response);
   }
 
-  Future<Response<dynamic>> putRaw(
-    String url, {
-    required List<int> data,
+  Future<Response<dynamic>> uploadRaw(
+    String url,
+    List<int> data, {
     Map<String, dynamic>? headers,
+    String method = 'PUT',
   }) async {
-    logger.d('PUT $url (raw upload)');
-    return _dio.put(
+    final upperMethod = method.toUpperCase();
+    logger.d('$upperMethod $url (raw upload)');
+    return _dio.request(
       url,
       data: Stream.fromIterable([data]),
-      options: Options(headers: headers),
+      options: Options(
+        method: upperMethod,
+        headers: headers,
+      ),
+    );
+  }
+
+  Future<Response<dynamic>> send(
+    String method,
+    String url, {
+    dynamic data,
+    Map<String, dynamic>? headers,
+  }) async {
+    final upperMethod = method.toUpperCase();
+    logger.d('$upperMethod $url');
+    return _dio.request(
+      url,
+      data: data,
+      options: Options(
+        method: upperMethod,
+        headers: headers,
+      ),
     );
   }
 

--- a/ai-scribe-copilot/lib/core/services/chunk_uploader.dart
+++ b/ai-scribe-copilot/lib/core/services/chunk_uploader.dart
@@ -105,6 +105,7 @@ class ChunkUploader {
       final presigned = await uploadSessionService.requestPresignedUrl(
         chunk.sessionId,
         chunk.sequence,
+        mimeType: 'audio/pcm',
       );
       final file = File(chunk.filePath);
       if (!await file.exists()) {
@@ -112,15 +113,11 @@ class ChunkUploader {
         await chunkStore.deleteChunk(chunk.id);
         return;
       }
-      final bytes = await file.readAsBytes();
-      await uploadSessionService.uploadChunk(
-        presigned.url,
-        bytes,
-        headers: presigned.headers,
-      );
+      await uploadSessionService.uploadChunk(presigned, file);
       await uploadSessionService.notifyChunkUploaded(
         chunk.sessionId,
         chunk.sequence,
+        request: presigned,
       );
       await chunkStore.markUploaded(chunk.id);
       await chunkStore.deleteChunk(chunk.id);

--- a/ai-scribe-copilot/lib/core/services/upload_session_service.dart
+++ b/ai-scribe-copilot/lib/core/services/upload_session_service.dart
@@ -1,13 +1,37 @@
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:path/path.dart' as path;
+
 import '../../utils/logger.dart';
 import '../models/upload_session.dart';
 import '../network/api_client.dart';
 import '../network/api_endpoints.dart';
 
-class PresignedUrl {
-  PresignedUrl({required this.url, required this.headers});
+class PresignedUploadRequest {
+  PresignedUploadRequest({
+    required this.url,
+    required this.method,
+    required this.headers,
+    required this.fields,
+    required this.fileFieldName,
+    this.fileName,
+    this.requiresMultipart = false,
+    this.gcsPath,
+    this.publicUrl,
+    this.mimeType,
+  });
 
   final String url;
+  final String method;
   final Map<String, dynamic> headers;
+  final Map<String, dynamic> fields;
+  final String fileFieldName;
+  final String? fileName;
+  final bool requiresMultipart;
+  final String? gcsPath;
+  final String? publicUrl;
+  final String? mimeType;
 }
 
 class UploadSessionService {
@@ -27,42 +51,149 @@ class UploadSessionService {
         'userId': userId,
       },
     );
-    final sessionId = response['sessionId'] as String;
+    final rawSessionId =
+        (response['sessionId'] ?? response['id'])?.toString().trim();
+    if (rawSessionId == null || rawSessionId.isEmpty) {
+      throw StateError(
+        'Upload session response did not include a session identifier.',
+      );
+    }
     return UploadSession(
-      sessionId: sessionId,
+      sessionId: rawSessionId,
       patientId: patientId,
       userId: userId,
       startedAt: DateTime.now().toUtc(),
     );
   }
 
-  Future<PresignedUrl> requestPresignedUrl(String sessionId, int sequence) async {
+  Future<PresignedUploadRequest> requestPresignedUrl(
+    String sessionId,
+    int sequence, {
+    String? mimeType,
+  }) async {
+    final payload = <String, dynamic>{
+      'sessionId': sessionId,
+      'chunkNumber': sequence,
+    };
+    if (mimeType != null && mimeType.isNotEmpty) {
+      payload['mimeType'] = mimeType;
+    }
     final response = await apiClient.post(
       ApiEndpoints.presignedUrl,
-      data: {
-        'sessionId': sessionId,
-        'sequence': sequence,
-      },
+      data: payload,
     );
-    return PresignedUrl(
-      url: response['url'] as String,
-      headers: response['headers'] != null
-          ? Map<String, dynamic>.from(response['headers'] as Map)
-          : const {},
+
+    final rawUrl = (response['url'] ?? response['presignedUrl'] ??
+            response['uploadUrl'] ?? response['signedUrl'])
+        ?.toString()
+        .trim();
+    if (rawUrl == null || rawUrl.isEmpty) {
+      throw StateError('Presigned URL response did not include an upload URL.');
+    }
+
+    final method = (response['method'] as String? ?? 'PUT').toUpperCase();
+    final headers = _normaliseMap(response['headers']);
+    final fields = _normaliseMap(response['fields']);
+    final inferredFileFieldName = response['fileFieldName']?.toString().trim();
+    final defaultFieldName = inferredFileFieldName?.isNotEmpty == true
+        ? inferredFileFieldName!
+        : rawUrl.contains('/api/upload-chunk/')
+            ? 'audio'
+            : 'file';
+
+    final requiresMultipart = response['requiresMultipart'] == true ||
+        response['requiresFormData'] == true ||
+        fields.isNotEmpty ||
+        method == 'POST' ||
+        (response.containsKey('presignedUrl') && !response.containsKey('url'));
+
+    return PresignedUploadRequest(
+      url: rawUrl,
+      method: method,
+      headers: headers,
+      fields: fields,
+      fileFieldName: defaultFieldName,
+      fileName: response['fileName']?.toString(),
+      requiresMultipart: requiresMultipart,
+      gcsPath: response['gcsPath']?.toString(),
+      publicUrl: response['publicUrl']?.toString(),
+      mimeType: mimeType ?? response['mimeType']?.toString(),
     );
   }
 
-  Future<void> uploadChunk(String url, List<int> bytes, {Map<String, dynamic>? headers}) async {
-    await apiClient.putRaw(url, data: bytes, headers: headers);
+  Future<void> uploadChunk(
+    PresignedUploadRequest request,
+    File file,
+  ) async {
+    final method = request.method;
+    logger.d(
+      'Uploading chunk to ${request.url} using $method (multipart: ${request.requiresMultipart}).',
+    );
+
+    if (request.requiresMultipart) {
+      final bytes = await file.readAsBytes();
+      final filename = request.fileName ?? path.basename(file.path);
+      final formFields = Map<String, dynamic>.from(request.fields);
+      formFields[request.fileFieldName] = MultipartFile.fromBytes(
+        bytes,
+        filename: filename,
+      );
+      final formData = FormData.fromMap(formFields);
+      await apiClient.send(
+        method,
+        request.url,
+        data: formData,
+        headers: request.headers.isEmpty ? null : request.headers,
+      );
+      return;
+    }
+
+    final bytes = await file.readAsBytes();
+    await apiClient.uploadRaw(
+      request.url,
+      bytes,
+      method: method,
+      headers: request.headers.isEmpty ? null : request.headers,
+    );
   }
 
-  Future<void> notifyChunkUploaded(String sessionId, int sequence) async {
+  Future<void> notifyChunkUploaded(
+    String sessionId,
+    int chunkNumber, {
+    PresignedUploadRequest? request,
+    bool? isLast,
+    int? totalChunksClient,
+  }) async {
+    final payload = <String, dynamic>{
+      'sessionId': sessionId,
+      'chunkNumber': chunkNumber,
+    };
+    if (request?.gcsPath != null) {
+      payload['gcsPath'] = request!.gcsPath;
+    }
+    if (request?.publicUrl != null) {
+      payload['publicUrl'] = request!.publicUrl;
+    }
+    if (request?.mimeType != null) {
+      payload['mimeType'] = request!.mimeType;
+    }
+    if (isLast != null) {
+      payload['isLast'] = isLast;
+    }
+    if (totalChunksClient != null) {
+      payload['totalChunksClient'] = totalChunksClient;
+    }
+
     await apiClient.post(
       ApiEndpoints.notifyChunkUploaded,
-      data: {
-        'sessionId': sessionId,
-        'sequence': sequence,
-      },
+      data: payload,
     );
+  }
+
+  Map<String, dynamic> _normaliseMap(dynamic source) {
+    if (source is Map) {
+      return source.map((key, value) => MapEntry(key.toString(), value));
+    }
+    return <String, dynamic>{};
   }
 }


### PR DESCRIPTION
## Summary
- normalise upload session responses so start-session works with either `sessionId` or `id`
- teach the presigned URL flow to understand multiple response shapes, infer multipart uploads, and forward optional metadata
- extend the API client and chunk uploader so chunks can be sent with raw PUTs or multipart form uploads before notifying the backend

## Testing
- Not run (Flutter tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d7a735d924832c9db1f162b58bb9ea