### PR TITLE
Fix API base URL joining for backend requests

### DIFF
--- a/ai-scribe-copilot/lib/core/config/app_config.dart
+++ b/ai-scribe-copilot/lib/core/config/app_config.dart
@@ -60,7 +60,7 @@ class AppConfig {
   }) {
     final trimmedBaseOverride = baseOverride.trim();
     if (trimmedBaseOverride.isNotEmpty) {
-      return trimmedBaseOverride;
+      return _ensureTrailingSlash(trimmedBaseOverride);
     }
 
     final trimmedHostOverride = hostOverride.trim();
@@ -94,23 +94,30 @@ class AppConfig {
         port: port,
         pathSegments: pathSegments,
       );
-      return uri.toString();
+      return _ensureTrailingSlash(uri.toString());
     }
 
     if (isWeb) {
-      return 'http://localhost:3000/api';
+      return 'http://localhost:3000/api/';
     }
 
     switch (platform) {
       case TargetPlatform.android:
-        return 'http://10.0.2.2:3000/api';
+        return 'http://10.0.2.2:3000/api/';
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
       case TargetPlatform.windows:
       case TargetPlatform.linux:
-        return 'http://localhost:3000/api';
+        return 'http://localhost:3000/api/';
       case TargetPlatform.fuchsia:
-        return 'http://localhost:3000/api';
+        return 'http://localhost:3000/api/';
     }
+  }
+
+  static String _ensureTrailingSlash(String baseUrl) {
+    if (baseUrl.endsWith('/')) {
+      return baseUrl;
+    }
+    return '$baseUrl/';
   }
 }

--- a/ai-scribe-copilot/lib/core/network/api_endpoints.dart
+++ b/ai-scribe-copilot/lib/core/network/api_endpoints.dart
@@ -3,11 +3,11 @@ import '../config/app_config.dart';
 class ApiEndpoints {
   static String get baseUrl => AppConfig.apiBaseUrl;
 
-  static const String startSession = '/v1/upload-session';
-  static const String presignedUrl = '/v1/get-presigned-url';
-  static const String notifyChunkUploaded = '/v1/notify-chunk-uploaded';
-  static const String patients = '/v1/patients';
-  static const String addPatient = '/v1/add-patient-ext';
+  static const String startSession = 'v1/upload-session';
+  static const String presignedUrl = 'v1/get-presigned-url';
+  static const String notifyChunkUploaded = 'v1/notify-chunk-uploaded';
+  static const String patients = 'v1/patients';
+  static const String addPatient = 'v1/add-patient-ext';
   static String sessionsByPatient(String patientId) =>
-      '/v1/fetch-session-by-patient/$patientId';
+      'v1/fetch-session-by-patient/$patientId';
 }

--- a/ai-scribe-copilot/test/core/config/app_config_test.dart
+++ b/ai-scribe-copilot/test/core/config/app_config_test.dart
@@ -10,7 +10,7 @@ void main() {
           baseOverride: '  https://example.com/api  ',
           platform: TargetPlatform.android,
         ),
-        'https://example.com/api',
+        'https://example.com/api/',
       );
     });
 
@@ -22,7 +22,7 @@ void main() {
           pathOverride: 'api',
           schemeOverride: 'http',
         ),
-        'http://[2409:40d4:2405:9e6b:8000::]:3000/api',
+        'http://[2409:40d4:2405:9e6b:8000::]:3000/api/',
       );
     });
 
@@ -34,7 +34,7 @@ void main() {
           pathOverride: '/v1//patients/',
           schemeOverride: 'https',
         ),
-        'https://api.example.com:8080/v1/patients',
+        'https://api.example.com:8080/v1/patients/',
       );
     });
 
@@ -54,7 +54,7 @@ void main() {
           isWeb: true,
           platform: TargetPlatform.android,
         ),
-        'http://localhost:3000/api',
+        'http://localhost:3000/api/',
       );
     });
 
@@ -63,7 +63,7 @@ void main() {
         AppConfig.resolveBaseUrlForTest(
           platform: TargetPlatform.android,
         ),
-        'http://10.0.2.2:3000/api',
+        'http://10.0.2.2:3000/api/',
       );
     });
 
@@ -72,7 +72,7 @@ void main() {
         AppConfig.resolveBaseUrlForTest(
           platform: TargetPlatform.windows,
         ),
-        'http://localhost:3000/api',
+        'http://localhost:3000/api/',
       );
     });
   });


### PR DESCRIPTION
## Summary
- ensure AppConfig appends a trailing slash to resolved API base URLs so the `/api` segment is preserved
- remove leading slashes from API endpoint constants to prevent Dio from discarding the base path
- update configuration tests to cover the new trailing slash behavior

## Testing
- Not run (Flutter SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d7a9eaabd4832ca9268e1a31cb04a3