### PR TITLE
Handle add patient responses without wrapper

### DIFF
--- a/ai-scribe-copilot/lib/core/services/patient_service.dart
+++ b/ai-scribe-copilot/lib/core/services/patient_service.dart
@@ -46,6 +46,19 @@ class PatientService {
         if (mrn != null) 'mrn': mrn,
       },
     );
-    return Patient.fromJson(Map<String, dynamic>.from(response['patient'] as Map));
+    final payload = response['patient'];
+    if (payload is Map) {
+      return Patient.fromJson(
+        Map<String, dynamic>.from(payload as Map<dynamic, dynamic>),
+      );
+    }
+
+    if (response.isNotEmpty) {
+      return Patient.fromJson(
+        Map<String, dynamic>.from(response as Map<dynamic, dynamic>),
+      );
+    }
+
+    throw StateError('Invalid response when adding patient: $response');
   }
 }


### PR DESCRIPTION
## Summary
- update the patient service to handle add patient responses that return the patient payload directly
- surface a clearer error when the backend response is empty or malformed

## Testing
- flutter analyze *(fails: `flutter` command is unavailable in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7acbcd7b4832cbd7bcc7565d85ada