### PR TITLE
Ensure patients are tied to demo user

### DIFF
--- a/ai-scribe-copilot/lib/core/constants/user_constants.dart
+++ b/ai-scribe-copilot/lib/core/constants/user_constants.dart
@@ -1,0 +1,5 @@
+class UserConstants {
+  const UserConstants._();
+
+  static const String demoUserId = 'demo-user';
+}

--- a/ai-scribe-copilot/lib/core/services/patient_service.dart
+++ b/ai-scribe-copilot/lib/core/services/patient_service.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 
 import '../../utils/logger.dart';
+import '../constants/user_constants.dart';
 import '../models/patient.dart';
 import '../network/api_client.dart';
 import '../network/api_endpoints.dart';
@@ -11,7 +12,9 @@ class PatientService {
   final ApiClient apiClient;
   final Logger logger;
 
-  Future<List<Patient>> fetchPatients(String userId) async {
+  Future<List<Patient>> fetchPatients([
+    String userId = UserConstants.demoUserId,
+  ]) async {
     try {
       final response = await apiClient.get(
         ApiEndpoints.patients,
@@ -37,11 +40,13 @@ class PatientService {
     required String name,
     required DateTime? dateOfBirth,
     required String? mrn,
+    String userId = UserConstants.demoUserId,
   }) async {
     final response = await apiClient.post(
       ApiEndpoints.addPatient,
       data: {
         'name': name,
+        'userId': userId,
         if (dateOfBirth != null) 'dateOfBirth': dateOfBirth.toIso8601String(),
         if (mrn != null) 'mrn': mrn,
       },

--- a/ai-scribe-copilot/lib/features/patients/patient_list_screen.dart
+++ b/ai-scribe-copilot/lib/features/patients/patient_list_screen.dart
@@ -1,14 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../core/constants/user_constants.dart';
 import '../../core/models/patient.dart';
 import '../../core/network/api_endpoints.dart';
 import '../../shared/providers.dart';
 
 final _patientListProvider = FutureProvider<List<Patient>>((ref) async {
   final patientService = ref.watch(patientServiceProvider);
-  const demoUserId = 'demo-user';
-  return patientService.fetchPatients(demoUserId);
+  return patientService.fetchPatients(UserConstants.demoUserId);
 });
 
 class PatientListScreen extends ConsumerWidget {
@@ -184,6 +184,7 @@ class PatientListScreen extends ConsumerWidget {
                         name: nameController.text,
                         dateOfBirth: dob,
                         mrn: mrnController.text.isEmpty ? null : mrnController.text,
+                        userId: UserConstants.demoUserId,
                       );
                       ref.invalidate(_patientListProvider);
                       if (context.mounted) {

--- a/ai-scribe-copilot/lib/features/recording/screens/recording_screen.dart
+++ b/ai-scribe-copilot/lib/features/recording/screens/recording_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/constants/user_constants.dart';
 import '../../../core/models/patient.dart';
 import '../controllers/recording_controller.dart';
 import '../state/recording_state.dart';
@@ -23,7 +24,11 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
     super.initState();
     Future.microtask(() async {
       final controller = ref.read(recordingControllerProvider.notifier);
-      await controller.start(widget.patient.id, widget.patient.name, 'demo-user');
+      await controller.start(
+        widget.patient.id,
+        widget.patient.name,
+        UserConstants.demoUserId,
+      );
     });
   }
 


### PR DESCRIPTION
## Summary
- add a shared demo user identifier constant for UI and services
- include the demo user id when fetching and creating patients so new records appear in lists
- update recording startup to reference the shared demo user id

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7af6297a8832ca93559d1d7a8b3e1