### PR TITLE
Fix recorder stop during dispose

### DIFF
--- a/ai-scribe-copilot/lib/features/recording/screens/recording_screen.dart
+++ b/ai-scribe-copilot/lib/features/recording/screens/recording_screen.dart
@@ -19,12 +19,14 @@ class RecordingScreen extends ConsumerStatefulWidget {
 }
 
 class _RecordingScreenState extends ConsumerState<RecordingScreen> {
+  late final RecordingController _controller;
+
   @override
   void initState() {
     super.initState();
+    _controller = ref.read(recordingControllerProvider.notifier);
     Future.microtask(() async {
-      final controller = ref.read(recordingControllerProvider.notifier);
-      await controller.start(
+      await _controller.start(
         widget.patient.id,
         widget.patient.name,
         UserConstants.demoUserId,
@@ -34,8 +36,7 @@ class _RecordingScreenState extends ConsumerState<RecordingScreen> {
 
   @override
   void dispose() {
-    final controller = ref.read(recordingControllerProvider.notifier);
-    unawaited(controller.stop());
+    unawaited(_controller.stop());
     super.dispose();
   }
 


### PR DESCRIPTION
## Summary
- store the recording controller in the recording screen state
- reuse the cached controller during dispose to avoid reading a disposed ref

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7b0f33164832cb4decdfa4952c2f2