### PR TITLE
Handle limited microphone permission states

### DIFF
--- a/ai-scribe-copilot/lib/screens/home_screen.dart
+++ b/ai-scribe-copilot/lib/screens/home_screen.dart
@@ -6,6 +6,7 @@ import '../models/recording_session.dart';
 import '../services/audio_recording_service.dart';
 import '../services/api_service.dart';
 import '../services/local_storage_service.dart';
+import '../utils/permission_utils.dart';
 import '../widgets/patient_list_widget.dart';
 import '../widgets/recording_controls_widget.dart';
 import '../widgets/audio_visualizer_widget.dart';
@@ -92,11 +93,11 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
   Future<bool> _requestPermissions() async {
     final microphoneStatus = await Permission.microphone.status;
-    final microphonePermission = microphoneStatus.isGranted
+    final microphonePermission = hasMicrophoneAccess(microphoneStatus)
         ? microphoneStatus
         : await Permission.microphone.request();
 
-    if (!microphonePermission.isGranted) {
+    if (!hasMicrophoneAccess(microphonePermission)) {
       if (mounted) {
         final snackBar = SnackBar(
           content: const Text('Microphone permission is required for recording'),

--- a/ai-scribe-copilot/lib/screens/patient_detail_screen.dart
+++ b/ai-scribe-copilot/lib/screens/patient_detail_screen.dart
@@ -7,6 +7,7 @@ import '../models/recording_session.dart';
 import '../services/audio_recording_service.dart';
 import '../services/api_service.dart';
 import '../services/local_storage_service.dart';
+import '../utils/permission_utils.dart';
 import '../widgets/recording_session_list_widget.dart';
 
 class PatientDetailScreen extends ConsumerStatefulWidget {
@@ -82,9 +83,11 @@ class _PatientDetailScreenState extends ConsumerState<PatientDetailScreen> {
 
   Future<bool> _ensureMicrophonePermission() async {
     final status = await Permission.microphone.status;
-    final permission = status.isGranted ? status : await Permission.microphone.request();
+    final permission = hasMicrophoneAccess(status)
+        ? status
+        : await Permission.microphone.request();
 
-    if (!permission.isGranted) {
+    if (!hasMicrophoneAccess(permission)) {
       if (mounted) {
         final snackBar = SnackBar(
           content: const Text('Microphone permission is required for recording'),

--- a/ai-scribe-copilot/lib/services/audio_recording_service.dart
+++ b/ai-scribe-copilot/lib/services/audio_recording_service.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 import 'package:flutter_sound/flutter_sound.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:permission_handler/permission_handler.dart';
+
+import '../utils/permission_utils.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:uuid/uuid.dart';
 import '../models/audio_chunk.dart';
@@ -123,12 +125,12 @@ class AudioRecordingService {
 
   Future<void> _ensureMicrophonePermissionGranted() async {
     final status = await Permission.microphone.status;
-    if (status.isGranted) {
+    if (hasMicrophoneAccess(status)) {
       return;
     }
 
     final result = await Permission.microphone.request();
-    if (!result.isGranted) {
+    if (!hasMicrophoneAccess(result)) {
       throw Exception('Microphone permission denied');
     }
   }

--- a/ai-scribe-copilot/lib/utils/permission_utils.dart
+++ b/ai-scribe-copilot/lib/utils/permission_utils.dart
@@ -1,0 +1,9 @@
+import 'package:permission_handler/permission_handler.dart';
+
+/// Utility helpers for working with runtime permissions.
+///
+/// Keeping this in a shared file avoids subtle inconsistencies across
+/// different screens and services when we check for microphone access.
+bool hasMicrophoneAccess(PermissionStatus status) {
+  return status.isGranted || status.isLimited || status.isProvisional;
+}


### PR DESCRIPTION
## Summary
- add a shared helper for checking microphone access states
- update all recording entry points to accept limited/provisional microphone permissions
- ensure audio service throws only when microphone access is actually unavailable

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7b7ade9bc832c80fd634cd5bb77f4